### PR TITLE
chore: Configure S3 config, add make region configurable

### DIFF
--- a/HerPublicWebsite.BusinessLogic/ExternalServices/S3FileWriter/S3FileWriter.cs
+++ b/HerPublicWebsite.BusinessLogic/ExternalServices/S3FileWriter/S3FileWriter.cs
@@ -34,11 +34,8 @@ public class S3FileWriter : IS3FileWriter
         
         try
         {
-            // TODO: BEISHER-240 do we need a username/password at all - or is the user this is running as get given permissions externally?
-            // https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/creds-assign.html
-            // https://stackoverflow.com/questions/47124876/how-to-specify-aws-credentials-in-c-sharp-net-core-console-program
-            var s3Client = new AmazonS3Client(RegionEndpoint.EUWest2); // London
-            
+            var s3Client = new AmazonS3Client(config.Region);
+
             var fileTransferUtility = new TransferUtility(s3Client);
 
             await fileTransferUtility.UploadAsync(fileContent, config.BucketName, keyName);

--- a/HerPublicWebsite.BusinessLogic/ExternalServices/S3FileWriter/S3FileWriterConfiguration.cs
+++ b/HerPublicWebsite.BusinessLogic/ExternalServices/S3FileWriter/S3FileWriterConfiguration.cs
@@ -1,8 +1,12 @@
-﻿namespace HerPublicWebsite.BusinessLogic.ExternalServices.S3FileWriter;
+﻿using Amazon;
+
+namespace HerPublicWebsite.BusinessLogic.ExternalServices.S3FileWriter;
 
 public class S3FileWriterConfiguration
 {
     public const string ConfigSection = "S3";
 
     public string BucketName { get; set; }
+
+    public RegionEndpoint Region { get; set; }
 }

--- a/HerPublicWebsite/Startup.cs
+++ b/HerPublicWebsite/Startup.cs
@@ -61,14 +61,13 @@ namespace HerPublicWebsite
             services.AddScoped<QuestionnaireUpdater>();
             services.AddScoped<IQuestionFlowService, QuestionFlowService>();
             services.AddScoped<IRegularJobsService, RegularJobsService>();
-            services.AddScoped<IS3FileWriter, S3FileWriter>();
-            services.AddScoped<S3ReferralFileKeyGenerator>();
 
             services.AddMemoryCache();
             services.AddSingleton<StaticAssetsVersioningService>();
             // This allows encrypted cookies to be understood across multiple web server instances
             services.AddDataProtection().PersistKeysToDbContext<HerDbContext>();
 
+            ConfigureS3FileWriter(services);
             ConfigureEpcApi(services);
             ConfigureOsPlacesApi(services);
             ConfigureGovUkNotify(services);
@@ -147,6 +146,14 @@ namespace HerPublicWebsite
             services.AddScoped<IEmailSender, GovUkNotifyApi>();
             services.Configure<GovUkNotifyConfiguration>(
                 configuration.GetSection(GovUkNotifyConfiguration.ConfigSection));
+        }
+
+        private void ConfigureS3FileWriter(IServiceCollection services)
+        {
+            services.Configure<S3FileWriterConfiguration>(
+                configuration.GetSection(S3FileWriterConfiguration.ConfigSection));
+            services.AddScoped<IS3FileWriter, S3FileWriter>();
+            services.AddScoped<S3ReferralFileKeyGenerator>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/HerPublicWebsite/appsettings.Production.json
+++ b/HerPublicWebsite/appsettings.Production.json
@@ -12,6 +12,7 @@
     },
 
     "S3": {
-        "BucketName": "TODO production bucket name here? Or keep secret?"
+        "BucketName": "TODO production bucket name here? Or keep secret?",
+        "Region": "TODO production region"
     }
 }

--- a/HerPublicWebsite/appsettings.json
+++ b/HerPublicWebsite/appsettings.json
@@ -25,7 +25,8 @@
         "BaseUrl": "https://www.google-analytics.com"
     },
     "S3": {
-        "BucketName": "TODO dev bucket name here"
+        "BucketName": "desnz-her-portal-referrals",
+        "Region": "eu-west-2"
     },
 
     "SessionCache": {


### PR DESCRIPTION
We weren't adding the S3 configuration in Startup.cs, and at the same time I thought we may as well make the region configurable - unless we particularly want to hardcode `eu-west-2`?