### PR TITLE
feat: Add session expiry filter and corresponding page

### DIFF
--- a/HerPublicWebsite/Controllers/QuestionnaireController.cs
+++ b/HerPublicWebsite/Controllers/QuestionnaireController.cs
@@ -8,6 +8,7 @@ using HerPublicWebsite.BusinessLogic.Models;
 using HerPublicWebsite.BusinessLogic.Models.Enums;
 using HerPublicWebsite.BusinessLogic.Services.QuestionFlow;
 using HerPublicWebsite.ExternalServices.GoogleAnalytics;
+using HerPublicWebsite.Filters;
 using HerPublicWebsite.Models.Questionnaire;
 using HerPublicWebsite.Services;
 using HerPublicWebsite.Services.Cookies;
@@ -78,6 +79,7 @@ public class QuestionnaireController : Controller
     }
 
     [HttpGet("direct-to-eco/")]
+    [SessionExpiry]
     public IActionResult DirectToEco_Get()
     {
         var viewModel = new DirectToEcoViewModel
@@ -89,6 +91,7 @@ public class QuestionnaireController : Controller
     }
 
     [HttpGet("country/")]
+    [SessionExpiry]
     public IActionResult Country_Get()
     {
         var questionnaire = questionnaireService.GetQuestionnaire();
@@ -102,6 +105,7 @@ public class QuestionnaireController : Controller
     }
 
     [HttpPost("country/")]
+    [SessionExpiry]
     public IActionResult Country_Post(CountryViewModel viewModel)
     {
         if (!ModelState.IsValid)
@@ -116,6 +120,7 @@ public class QuestionnaireController : Controller
     }
 
     [HttpGet("service-unsuitable/")]
+    [SessionExpiry]
     public IActionResult ServiceUnsuitable_Get()
     {
         var questionnaire = questionnaireService.GetQuestionnaire();
@@ -129,6 +134,7 @@ public class QuestionnaireController : Controller
     }
 
     [HttpGet("ownership-status/")]
+    [SessionExpiry]
     public IActionResult OwnershipStatus_Get()
     {
         var questionnaire = questionnaireService.GetQuestionnaire();
@@ -143,6 +149,7 @@ public class QuestionnaireController : Controller
     }
 
     [HttpPost("ownership-status/")]
+    [SessionExpiry]
     public IActionResult OwnershipStatus_Post(OwnershipStatusViewModel viewModel)
     {
         if (!ModelState.IsValid)
@@ -157,6 +164,7 @@ public class QuestionnaireController : Controller
     }
 
     [HttpGet("address/")]
+    [SessionExpiry]
     public IActionResult Address_Get()
     {
         var questionnaire = questionnaireService.GetQuestionnaire();
@@ -170,6 +178,7 @@ public class QuestionnaireController : Controller
     }
 
     [HttpPost("address/")]
+    [SessionExpiry]
     public IActionResult Address_Post(AddressViewModel viewModel)
     {
         if (viewModel.Postcode is not null && !viewModel.Postcode.IsValidUkPostcodeFormat())
@@ -196,6 +205,7 @@ public class QuestionnaireController : Controller
     }
 
     [HttpGet("address/{postcode}/{buildingNameOrNumber}")]
+    [SessionExpiry]
     public async Task<IActionResult> SelectAddress_Get(string postcode, string buildingNameOrNumber)
     {
         var questionnaire = questionnaireService.GetQuestionnaire();
@@ -211,6 +221,7 @@ public class QuestionnaireController : Controller
     }
 
     [HttpPost("address/{postcode}/{buildingNameOrNumber}")]
+    [SessionExpiry]
     public async Task<IActionResult> SelectAddress_Post(SelectAddressViewModel viewModel, string postcode, string buildingNameOrNumber)
     {
         if (!ModelState.IsValid)
@@ -237,6 +248,7 @@ public class QuestionnaireController : Controller
     }
 
     [HttpGet("review-epc")]
+    [SessionExpiry]
     public IActionResult ReviewEpc_Get()
     {
         var questionnaire = questionnaireService.GetQuestionnaire();
@@ -249,6 +261,7 @@ public class QuestionnaireController : Controller
     }
 
     [HttpPost("review-epc")]
+    [SessionExpiry]
     public IActionResult ReviewEpc_Post(ReviewEpcViewModel viewModel)
     {
         if (!ModelState.IsValid)
@@ -263,6 +276,7 @@ public class QuestionnaireController : Controller
     }
 
     [HttpGet("address/manual")]
+    [SessionExpiry]
     public IActionResult ManualAddress_Get()
     {
         var questionnaire = questionnaireService.GetQuestionnaire();
@@ -280,6 +294,7 @@ public class QuestionnaireController : Controller
     }
 
     [HttpPost("address/manual")]
+    [SessionExpiry]
     public async Task<IActionResult> ManualAddress_Post(ManualAddressViewModel viewModel)
     {
         if (viewModel.Postcode is not null && !viewModel.Postcode.IsValidUkPostcodeFormat())
@@ -307,6 +322,7 @@ public class QuestionnaireController : Controller
     }
 
     [HttpGet("income")]
+    [SessionExpiry]
     public IActionResult HouseholdIncome_Get()
     {
         var questionnaire = questionnaireService.GetQuestionnaire();
@@ -320,6 +336,7 @@ public class QuestionnaireController : Controller
     }
 
     [HttpPost("income")]
+    [SessionExpiry]
     public IActionResult HouseholdIncome_Post(HouseholdIncomeViewModel viewModel)
     {
         if (!ModelState.IsValid)
@@ -335,12 +352,14 @@ public class QuestionnaireController : Controller
     }
 
     [HttpGet("check")]
+    [SessionExpiry]
     public IActionResult CheckAnswers_Get()
     {
         return RedirectToAction(nameof(StaticPagesController.Index), "StaticPages");
     }
 
     [HttpPost("check")]
+    [SessionExpiry]
     public IActionResult CheckAnswers_Post()
     {
         return RedirectToAction(nameof(StaticPagesController.Index), "StaticPages");

--- a/HerPublicWebsite/Controllers/StaticPagesController.cs
+++ b/HerPublicWebsite/Controllers/StaticPagesController.cs
@@ -21,4 +21,10 @@ public class StaticPagesController : Controller
     {
         return View("PrivacyPolicy");
     }
+
+    [HttpGet("/session-expired")]
+    public IActionResult SessionExpired()
+    {
+        return View("SessionExpired");
+    }
 }

--- a/HerPublicWebsite/Filters/SessionExpiryAttribute.cs
+++ b/HerPublicWebsite/Filters/SessionExpiryAttribute.cs
@@ -1,0 +1,22 @@
+﻿using System.Linq;
+using HerPublicWebsite.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace HerPublicWebsite.Filters;
+
+public class SessionExpiryAttribute : ActionFilterAttribute
+{
+    public override void OnActionExecuting(ActionExecutingContext context)
+    {
+        if (!context.HttpContext.Session.Keys.Any())
+        {
+            context.Result = new RedirectToActionResult(
+                nameof(StaticPagesController.SessionExpired),
+                "StaticPages",
+                null);
+            return;
+        }
+        base.OnActionExecuting(context);
+    }
+}

--- a/HerPublicWebsite/Views/StaticPages/SessionExpired.cshtml
+++ b/HerPublicWebsite/Views/StaticPages/SessionExpired.cshtml
@@ -1,0 +1,20 @@
+@using HerPublicWebsite.Controllers
+@{
+    ViewBag.Title = "Session expired";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">
+            Your answers have been deleted
+        </h1>
+        <div class="govuk-body">
+            <p>We have deleted your answers because you did not do anything for 10 minutes.
+                This is to protect your information.</p>
+            <p>You will need to start again.</p>
+        </div>
+        <a href="@Url.Action(nameof(StaticPagesController.Index), "StaticPages")" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+            Start again
+        </a>
+    </div>
+</div>


### PR DESCRIPTION
Added a filter to every action in the questionnaire flow except the gas boiler question, and without a session it will redirect you to a new session expired page:

![image](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-beta/assets/9695026/ef136e43-6447-4731-a2e3-908eaca79c5a)
