### PR TITLE
BEISHER-714: Add alert role to success boxes

### DIFF
--- a/HerPublicWebsite/Views/Questionnaire/Confirmation.cshtml
+++ b/HerPublicWebsite/Views/Questionnaire/Confirmation.cshtml
@@ -49,7 +49,8 @@
                    {
                        TitleText = "Success",
                        Text = Model.CanNotifyAboutFutureSchemes is YesOrNo.Yes ? "Your contact details have been submitted." : "Your answers have been submitted.",
-                       Classes = "govuk-notification-banner--success"
+                       Classes = "govuk-notification-banner--success",
+                       Role = "alert"
                    })
         }
         else

--- a/HerPublicWebsite/Views/Questionnaire/Ineligible.cshtml
+++ b/HerPublicWebsite/Views/Questionnaire/Ineligible.cshtml
@@ -60,6 +60,7 @@
                            Type = "success",
                            TitleText = "Success",
                            Text = "Your contact details have been submitted.",
+                           Role = "alert"
                        }
                        )
         }

--- a/HerPublicWebsite/Views/Questionnaire/NotTakingPart.cshtml
+++ b/HerPublicWebsite/Views/Questionnaire/NotTakingPart.cshtml
@@ -42,6 +42,7 @@
                            Type = "success",
                            TitleText = "Success",
                            Text = "Your contact details have been submitted.",
+                           Role = "alert"
                        }
                        )
         }


### PR DESCRIPTION
The alert role causes screenreaders to prioritise the success alert box, so it is focused and read first when the page loads (which is good here as it is just an alert added to the previous page)
