### PR TITLE
BH-769: Make all cookies have safer settings

### DIFF
--- a/HerPublicWebsite/Services/Cookies/CookieService.cs
+++ b/HerPublicWebsite/Services/Cookies/CookieService.cs
@@ -90,6 +90,12 @@ public class CookieService
         response.Cookies.Append(
             cookieName,
             cookieString,
-            new CookieOptions {Secure = true, SameSite = SameSiteMode.Lax, MaxAge = TimeSpan.FromDays(Configuration.DefaultDaysUntilExpiry)});
+            new CookieOptions
+            {
+                Secure = true,
+                SameSite = SameSiteMode.Lax,
+                MaxAge = TimeSpan.FromDays(Configuration.DefaultDaysUntilExpiry),
+                HttpOnly = true
+            });
     }
 }

--- a/HerPublicWebsite/Startup.cs
+++ b/HerPublicWebsite/Startup.cs
@@ -28,6 +28,7 @@ using HerPublicWebsite.Services;
 using HerPublicWebsite.Services.Cookies;
 using HerPublicWebsite.BusinessLogic.ExternalServices.OsPlaces;
 using HerPublicWebsite.BusinessLogic.Services.CsvFileCreator;
+using Microsoft.AspNetCore.Http;
 
 namespace HerPublicWebsite
 {
@@ -103,6 +104,7 @@ namespace HerPublicWebsite
                 options.IdleTimeout = TimeSpan.FromMinutes(30);
                 options.Cookie.HttpOnly = true;
                 options.Cookie.IsEssential = true;
+                options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
             });
 
             services.AddHsts(options =>
@@ -134,7 +136,12 @@ namespace HerPublicWebsite
             services.Configure<CookieServiceConfiguration>(
                 configuration.GetSection(CookieServiceConfiguration.ConfigSection));
             // Change the default antiforgery cookie name so it doesn't include Asp.Net for security reasons
-            services.AddAntiforgery(options => options.Cookie.Name = "Antiforgery");
+            services.AddAntiforgery(options =>
+            {
+                options.Cookie.Name = "Antiforgery";
+                options.Cookie.HttpOnly = true;
+                options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+            });
             services.AddScoped<CookieService, CookieService>();
         }
 


### PR DESCRIPTION
After completing the questionnaire, all three created cookies have `HttpOnly` and `Secure` set to true, as advised
![image](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-beta/assets/4410524/6b5973b5-7a9c-4b3f-83e5-b1a5b087e150)
