### PR TITLE
BEISHER-801: Fixed low EPCs being reported as Unknown

### DIFF
--- a/HerPublicWebsite.BusinessLogic/Models/Questionnaire.cs
+++ b/HerPublicWebsite.BusinessLogic/Models/Questionnaire.cs
@@ -101,7 +101,7 @@ public record Questionnaire
                 return EpcRating.Unknown;
             }
 
-            if (EpcDetailsAreCorrect is not true)
+            if (EpcDetailsAreCorrect is false)
             {
                 return EpcRating.Unknown;
             }


### PR DESCRIPTION
Just a small logic error, since `EpcConfirmedCorrect` is `null` if you never went to the confirmation page
