### PR TITLE
Beisher 808 filter addresses

### DIFF
--- a/HerPublicWebsite.BusinessLogic/ExternalServices/OsPlaces/OsPlacesApi.cs
+++ b/HerPublicWebsite.BusinessLogic/ExternalServices/OsPlaces/OsPlacesApi.cs
@@ -46,14 +46,17 @@ public class OsPlacesApi : IOsPlacesApi
                 }
             }
             
-            // Join results based on UPRN
+            // Filter and parse DPA and LPI addresses
             var dpaAddresses = results
                 .Where(r => r.Dpa is not null)
                 .Select(r => r.Dpa.Parse());
+            
+            // The LPI dataset contains addresses that aren't residential properties, we want to filter those out
             var lpiAddresses = results
-                .Where(r => r.Lpi is not null)
+                .Where(r => r.Lpi is not null && r.Lpi.IsCurrentResidential())
                 .Select(r => r.Lpi.Parse());
 
+            // Join results based on UPRN
             var joinedAddresses = dpaAddresses.UnionBy(lpiAddresses, a => a.Uprn).ToList();
 
             var filteredResults = buildingNameOrNumber is null

--- a/HerPublicWebsite.BusinessLogic/ExternalServices/OsPlaces/OsPlacesLpiDto.cs
+++ b/HerPublicWebsite.BusinessLogic/ExternalServices/OsPlaces/OsPlacesLpiDto.cs
@@ -92,6 +92,18 @@ public class OsPlacesLpiDto
             Uprn = Uprn
         };
     }
+    
+    public bool IsCurrentResidential()
+    {
+        return PostalAddressCode != "N" // is a postal address
+               && LpiLogicalStatusCode == "1" // only want current addresses
+               && (
+                   ClassificationCode.StartsWith("R") // Residential addresses
+                   || ClassificationCode.StartsWith("CE") // Educational addresses
+                   || ClassificationCode.StartsWith("X") // Dual-use (residential and commercial) addresses
+                   || ClassificationCode.StartsWith("M") // Military addresses
+               );
+    }
 
     private string ToTitleCase(string text)
     {

--- a/HerPublicWebsite.UnitTests/BusinessLogic/ExternalServices/OsPlaces/OsPlacesApiTests.cs
+++ b/HerPublicWebsite.UnitTests/BusinessLogic/ExternalServices/OsPlaces/OsPlacesApiTests.cs
@@ -322,6 +322,36 @@ public class OsPlacesApiTests
         // Assert
         result.Should().BeEquivalentTo(correctAddresses);
     }
+    
+    [Test]
+    public async Task GetAddressesAsync_WhenReceivesNonCurrentResidentialLpiResults_RemovesAddresses()
+    {
+        // Arrange
+        mockHttpHandler.Expect("http://test.com/search/places/v1/postcode?postcode=AB1%202CD")
+            .WithHeaders("Key", "testKey")
+            .Respond("application/json", DummyOsPlacesResponseWithNonResidentialResults);
+
+        var correctAddresses = new List<Address>
+        {
+            new()
+            {
+                AddressLine1 = "Premises In Unit 2, Example Studios",
+                AddressLine2 = "1–10, Example Road",
+                Town = "London",
+                Postcode = "AB1 2CD",
+                County = null,
+                Uprn = "12345678904",
+                LocalCustodianCode = "5210"
+            },
+        };
+
+        // Act
+        var result = await underTest.GetAddressesAsync("AB1 2CD", "Non matching name");
+        
+        // Assert
+        result.Should().BeEquivalentTo(correctAddresses);
+    }
+    
 
     // This is a real response from the API that has had it's data replaced with dummy values
     private const string DummyOsPlacesResponse = @"{
@@ -726,7 +756,7 @@ public class OsPlacesApiTests
                 ""Y_COORDINATE"": 1234567.78,
                 ""STATUS"": ""APPROVED"",
                 ""LOGICAL_STATUS_CODE"": ""1"",
-                ""CLASSIFICATION_CODE"": ""CR07"",
+                ""CLASSIFICATION_CODE"": ""RD07"",
                 ""CLASSIFICATION_CODE_DESCRIPTION"": ""Restaurant / Cafeteria"",
                 ""LOCAL_CUSTODIAN_CODE"": 5210,
                 ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""CAMDEN"",
@@ -771,7 +801,7 @@ public class OsPlacesApiTests
                 ""Y_COORDINATE"": 1234567.78,
                 ""STATUS"": ""APPROVED"",
                 ""LOGICAL_STATUS_CODE"": ""1"",
-                ""CLASSIFICATION_CODE"": ""C"",
+                ""CLASSIFICATION_CODE"": ""RD01"",
                 ""CLASSIFICATION_CODE_DESCRIPTION"": ""Commercial"",
                 ""LOCAL_CUSTODIAN_CODE"": 5210,
                 ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""CAMDEN"",
@@ -817,7 +847,7 @@ public class OsPlacesApiTests
                 ""Y_COORDINATE"": 1234567.78,
                 ""STATUS"": ""APPROVED"",
                 ""LOGICAL_STATUS_CODE"": ""1"",
-                ""CLASSIFICATION_CODE"": ""CL06"",
+                ""CLASSIFICATION_CODE"": ""RD06"",
                 ""CLASSIFICATION_CODE_DESCRIPTION"": ""Indoor / Outdoor Leisure / Sporting Activity / Centre"",
                 ""LOCAL_CUSTODIAN_CODE"": 5210,
                 ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""CAMDEN"",
@@ -862,7 +892,7 @@ public class OsPlacesApiTests
                 ""Y_COORDINATE"": 1234567.78,
                 ""STATUS"": ""APPROVED"",
                 ""LOGICAL_STATUS_CODE"": ""1"",
-                ""CLASSIFICATION_CODE"": ""CE02"",
+                ""CLASSIFICATION_CODE"": ""RD02"",
                 ""CLASSIFICATION_CODE_DESCRIPTION"": ""Children’s Nursery / Crèche"",
                 ""LOCAL_CUSTODIAN_CODE"": 5210,
                 ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""CAMDEN"",
@@ -907,7 +937,7 @@ public class OsPlacesApiTests
                 ""Y_COORDINATE"": 1234567.78,
                 ""STATUS"": ""APPROVED"",
                 ""LOGICAL_STATUS_CODE"": ""1"",
-                ""CLASSIFICATION_CODE"": ""CO01"",
+                ""CLASSIFICATION_CODE"": ""RD01"",
                 ""CLASSIFICATION_CODE_DESCRIPTION"": ""Office / Work Studio"",
                 ""LOCAL_CUSTODIAN_CODE"": 5210,
                 ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""CAMDEN"",
@@ -965,7 +995,7 @@ public class OsPlacesApiTests
                 ""Y_COORDINATE"": 1234567.78,
                 ""STATUS"": ""APPROVED"",
                 ""LOGICAL_STATUS_CODE"": ""1"",
-                ""CLASSIFICATION_CODE"": ""PP"",
+                ""CLASSIFICATION_CODE"": ""RD01"",
                 ""CLASSIFICATION_CODE_DESCRIPTION"": ""Property Shell"",
                 ""LOCAL_CUSTODIAN_CODE"": 5150,
                 ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""BRENT"",
@@ -1187,6 +1217,209 @@ public class OsPlacesApiTests
                 ""LAST_UPDATE_DATE"": ""30/07/2017"",
                 ""ENTRY_DATE"": ""18/09/2007"",
                 ""BLPU_STATE_DATE"": ""01/04/2009"",
+                ""STREET_STATE_CODE"": ""2"",
+                ""STREET_STATE_CODE_DESCRIPTION"": ""Open"",
+                ""STREET_CLASSIFICATION_CODE"": ""8"",
+                ""STREET_CLASSIFICATION_CODE_DESCRIPTION"": ""All vehicles"",
+                ""LPI_LOGICAL_STATUS_CODE"": ""1"",
+                ""LPI_LOGICAL_STATUS_CODE_DESCRIPTION"": ""APPROVED"",
+                ""LANGUAGE"": ""EN"",
+                ""MATCH"": 1.0,
+                ""MATCH_DESCRIPTION"": ""EXACT""
+            }
+        }
+    ]
+}";
+    
+    // First property postal address code = N
+    // Second property logical status code = 0
+    // Third property classification code = CO
+    // Fourth is OK
+    private const string DummyOsPlacesResponseWithNonResidentialResults = @"{
+    ""header"": {
+        ""uri"" : ""https://api.os.uk/search/places/v1/postcode?postcode=AB1%202CD"",
+        ""query"" : ""postcode=AB1 2CD"",
+        ""offset"" : 0,
+        ""totalresults"" : 5,
+        ""format"" : ""JSON"",
+        ""dataset"" : ""LPI"",
+        ""lr"" : ""EN,CY"",
+        ""maxresults"" : 100,
+        ""epoch"" : ""101"",
+        ""lastupdate"" : ""2023-05-18"",
+        ""output_srs"" : ""EPSG:27700""
+      },
+    ""results"": [
+        {
+            ""LPI"": {
+                ""UPRN"": ""12345678901"",
+                ""ADDRESS"": ""CAFE, EXAMPLE STUDIOS, 1-10, EXAMPLE ROAD, LONDON, CAMDEN, AB1 2CD"",
+                ""USRN"": ""9876543"",
+                ""LPI_KEY"": ""5150L000099999"",
+                ""SAO_TEXT"": ""CAFE"",
+                ""PAO_START_NUMBER"": ""1"",
+                ""PAO_END_NUMBER"": ""10"",
+                ""PAO_TEXT"": ""EXAMPLE STUDIOS"",
+                ""STREET_DESCRIPTION"": ""EXAMPLE ROAD"",
+                ""TOWN_NAME"": ""LONDON"",
+                ""ADMINISTRATIVE_AREA"": ""CAMDEN"",
+                ""POSTCODE_LOCATOR"": ""AB1 2CD"",
+                ""RPC"": ""2"",
+                ""X_COORDINATE"": 1234567.78,
+                ""Y_COORDINATE"": 1234567.78,
+                ""STATUS"": ""APPROVED"",
+                ""LOGICAL_STATUS_CODE"": ""1"",
+                ""CLASSIFICATION_CODE"": ""RD07"",
+                ""CLASSIFICATION_CODE_DESCRIPTION"": ""Restaurant / Cafeteria"",
+                ""LOCAL_CUSTODIAN_CODE"": 5210,
+                ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""CAMDEN"",
+                ""COUNTRY_CODE"": ""E"",
+                ""COUNTRY_CODE_DESCRIPTION"": ""This record is within England"",
+                ""POSTAL_ADDRESS_CODE"": ""N"",
+                ""POSTAL_ADDRESS_CODE_DESCRIPTION"": ""A record which is postal and has a parent record which is linked to PAF"",
+                ""BLPU_STATE_CODE"": ""2"",
+                ""BLPU_STATE_CODE_DESCRIPTION"": ""In use"",
+                ""TOPOGRAPHY_LAYER_TOID"": ""osgb1000000000000"",
+                ""PARENT_UPRN"": ""9090909"",
+                ""LAST_UPDATE_DATE"": ""25/03/2022"",
+                ""ENTRY_DATE"": ""08/10/2002"",
+                ""BLPU_STATE_DATE"": ""08/10/2002"",
+                ""STREET_STATE_CODE"": ""2"",
+                ""STREET_STATE_CODE_DESCRIPTION"": ""Open"",
+                ""STREET_CLASSIFICATION_CODE"": ""8"",
+                ""STREET_CLASSIFICATION_CODE_DESCRIPTION"": ""All vehicles"",
+                ""LPI_LOGICAL_STATUS_CODE"": ""1"",
+                ""LPI_LOGICAL_STATUS_CODE_DESCRIPTION"": ""APPROVED"",
+                ""LANGUAGE"": ""EN"",
+                ""MATCH"": 1.0,
+                ""MATCH_DESCRIPTION"": ""EXACT""
+            }
+        },
+        {
+            ""LPI"": {
+                ""UPRN"": ""12345678902"",
+                ""ADDRESS"": ""CAR PARKING SPACES, EXAMPLE STUDIOS, 1-10, EXAMPLE ROAD, LONDON, CAMDEN, AB1 2CD"",
+                ""USRN"": ""9876543"",
+                ""LPI_KEY"": ""5150L000099999"",
+                ""SAO_TEXT"": ""CAR PARKING SPACES"",
+                ""PAO_START_NUMBER"": ""1"",
+                ""PAO_END_NUMBER"": ""10"",
+                ""PAO_TEXT"": ""EXAMPLE STUDIOS"",
+                ""STREET_DESCRIPTION"": ""EXAMPLE ROAD"",
+                ""TOWN_NAME"": ""LONDON"",
+                ""ADMINISTRATIVE_AREA"": ""CAMDEN"",
+                ""POSTCODE_LOCATOR"": ""AB1 2CD"",
+                ""RPC"": ""2"",
+                ""X_COORDINATE"": 1234567.78,
+                ""Y_COORDINATE"": 1234567.78,
+                ""STATUS"": ""APPROVED"",
+                ""LOGICAL_STATUS_CODE"": ""1"",
+                ""CLASSIFICATION_CODE"": ""RD07"",
+                ""CLASSIFICATION_CODE_DESCRIPTION"": ""Commercial"",
+                ""LOCAL_CUSTODIAN_CODE"": 5210,
+                ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""CAMDEN"",
+                ""COUNTRY_CODE"": ""E"",
+                ""COUNTRY_CODE_DESCRIPTION"": ""This record is within England"",
+                ""POSTAL_ADDRESS_CODE"": ""C"",
+                ""POSTAL_ADDRESS_CODE_DESCRIPTION"": ""A record which is postal and has a parent record which is linked to PAF"",
+                ""BLPU_STATE_CODE"": ""2"",
+                ""BLPU_STATE_CODE_DESCRIPTION"": ""In use"",
+                ""TOPOGRAPHY_LAYER_TOID"": ""osgb1000000000000"",
+                ""PARENT_UPRN"": ""9090909"",
+                ""LAST_UPDATE_DATE"": ""25/03/2022"",
+                ""ENTRY_DATE"": ""08/10/2002"",
+                ""BLPU_STATE_DATE"": ""08/10/2002"",
+                ""STREET_STATE_CODE"": ""2"",
+                ""STREET_STATE_CODE_DESCRIPTION"": ""Open"",
+                ""STREET_CLASSIFICATION_CODE"": ""8"",
+                ""STREET_CLASSIFICATION_CODE_DESCRIPTION"": ""All vehicles"",
+                ""LPI_LOGICAL_STATUS_CODE"": ""0"",
+                ""LPI_LOGICAL_STATUS_CODE_DESCRIPTION"": ""APPROVED"",
+                ""LANGUAGE"": ""EN"",
+                ""MATCH"": 1.0,
+                ""MATCH_DESCRIPTION"": ""EXACT""
+            }
+        },
+        {
+            ""LPI"": {
+                ""UPRN"": ""12345678903"",
+                ""ADDRESS"": ""EXAMPLE ORGANISATION, PREMISES IN UNIT 1, EXAMPLE STUDIOS, 1-10, EXAMPLE ROAD, LONDON, CAMDEN, AB1 2CD"",
+                ""USRN"": ""9876543"",
+                ""LPI_KEY"": ""5150L000099999"",
+                ""ORGANISATION"": ""EXAMPLE ORGANISATION"",
+                ""SAO_TEXT"": ""PREMISES IN UNIT 1"",
+                ""PAO_START_NUMBER"": ""1"",
+                ""PAO_END_NUMBER"": ""10"",
+                ""PAO_TEXT"": ""EXAMPLE STUDIOS"",
+                ""STREET_DESCRIPTION"": ""EXAMPLE ROAD"",
+                ""TOWN_NAME"": ""LONDON"",
+                ""ADMINISTRATIVE_AREA"": ""CAMDEN"",
+                ""POSTCODE_LOCATOR"": ""AB1 2CD"",
+                ""RPC"": ""2"",
+                ""X_COORDINATE"": 1234567.78,
+                ""Y_COORDINATE"": 1234567.78,
+                ""STATUS"": ""APPROVED"",
+                ""LOGICAL_STATUS_CODE"": ""1"",
+                ""CLASSIFICATION_CODE"": ""CO06"",
+                ""CLASSIFICATION_CODE_DESCRIPTION"": ""Indoor / Outdoor Leisure / Sporting Activity / Centre"",
+                ""LOCAL_CUSTODIAN_CODE"": 5210,
+                ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""CAMDEN"",
+                ""COUNTRY_CODE"": ""E"",
+                ""COUNTRY_CODE_DESCRIPTION"": ""This record is within England"",
+                ""POSTAL_ADDRESS_CODE"": ""D"",
+                ""POSTAL_ADDRESS_CODE_DESCRIPTION"": ""A record which is linked to PAF"",
+                ""BLPU_STATE_CODE"": ""2"",
+                ""BLPU_STATE_CODE_DESCRIPTION"": ""In use"",
+                ""TOPOGRAPHY_LAYER_TOID"": ""osgb1000000000000"",
+                ""PARENT_UPRN"": ""9090909"",
+                ""LAST_UPDATE_DATE"": ""25/03/2022"",
+                ""ENTRY_DATE"": ""08/10/2002"",
+                ""BLPU_STATE_DATE"": ""08/10/2002"",
+                ""STREET_STATE_CODE"": ""2"",
+                ""STREET_STATE_CODE_DESCRIPTION"": ""Open"",
+                ""STREET_CLASSIFICATION_CODE"": ""8"",
+                ""STREET_CLASSIFICATION_CODE_DESCRIPTION"": ""All vehicles"",
+                ""LPI_LOGICAL_STATUS_CODE"": ""1"",
+                ""LPI_LOGICAL_STATUS_CODE_DESCRIPTION"": ""APPROVED"",
+                ""LANGUAGE"": ""EN"",
+                ""MATCH"": 1.0,
+                ""MATCH_DESCRIPTION"": ""EXACT""
+            }
+        },
+        {
+            ""LPI"": {
+                ""UPRN"": ""12345678904"",
+                ""ADDRESS"": ""PREMISES IN UNIT 2, EXAMPLE STUDIOS, 1-10, EXAMPLE ROAD, LONDON, CAMDEN, AB1 2CD"",
+                ""USRN"": ""9876543"",
+                ""LPI_KEY"": ""5150L000099999"",
+                ""SAO_TEXT"": ""PREMISES IN UNIT 2"",
+                ""PAO_START_NUMBER"": ""1"",
+                ""PAO_END_NUMBER"": ""10"",
+                ""PAO_TEXT"": ""EXAMPLE STUDIOS"",
+                ""STREET_DESCRIPTION"": ""EXAMPLE ROAD"",
+                ""TOWN_NAME"": ""LONDON"",
+                ""ADMINISTRATIVE_AREA"": ""CAMDEN"",
+                ""POSTCODE_LOCATOR"": ""AB1 2CD"",
+                ""RPC"": ""2"",
+                ""X_COORDINATE"": 1234567.78,
+                ""Y_COORDINATE"": 1234567.78,
+                ""STATUS"": ""APPROVED"",
+                ""LOGICAL_STATUS_CODE"": ""1"",
+                ""CLASSIFICATION_CODE"": ""RD02"",
+                ""CLASSIFICATION_CODE_DESCRIPTION"": ""Children’s Nursery / Crèche"",
+                ""LOCAL_CUSTODIAN_CODE"": 5210,
+                ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""CAMDEN"",
+                ""COUNTRY_CODE"": ""E"",
+                ""COUNTRY_CODE_DESCRIPTION"": ""This record is within England"",
+                ""POSTAL_ADDRESS_CODE"": ""C"",
+                ""POSTAL_ADDRESS_CODE_DESCRIPTION"": ""A record which is postal and has a parent record which is linked to PAF"",
+                ""BLPU_STATE_CODE"": ""2"",
+                ""BLPU_STATE_CODE_DESCRIPTION"": ""In use"",
+                ""TOPOGRAPHY_LAYER_TOID"": ""osgb1000000000000"",
+                ""PARENT_UPRN"": ""9090909"",
+                ""LAST_UPDATE_DATE"": ""25/03/2022"",
+                ""ENTRY_DATE"": ""08/10/2002"",
+                ""BLPU_STATE_DATE"": ""08/10/2002"",
                 ""STREET_STATE_CODE"": ""2"",
                 ""STREET_STATE_CODE_DESCRIPTION"": ""Open"",
                 ""STREET_CLASSIFICATION_CODE"": ""8"",

--- a/HerPublicWebsite.UnitTests/BusinessLogic/ExternalServices/OsPlaces/OsPlacesApiTests.cs
+++ b/HerPublicWebsite.UnitTests/BusinessLogic/ExternalServices/OsPlaces/OsPlacesApiTests.cs
@@ -38,35 +38,64 @@ public class OsPlacesApiTests
     }
 
     [Test]
-    public async Task GetAddressesAsync_CalledWithValidPostcode_TranslatesResponseIntoAddresses()
+    public async Task GetAddressesAsync_WithJustLpiResults_ParsesAddress()
     {
         // Arrange
         mockHttpHandler.Expect("http://test.com/search/places/v1/postcode?postcode=AB1%202CD")
             .WithHeaders("Key", "testKey")
-            .Respond("application/json", DummyOsPlacesResponse);
+            .Respond("application/json", DummyResponseWithJustLpiData);
 
         var correctAddresses = new List<Address>
         {
-            new Address
+            new()
             {
-                AddressLine1 = "45, The Dene",
+                AddressLine1 = "85, Test Road",
                 AddressLine2 = "",
-                Town = "Luton",
+                Town = "London",
                 Postcode = "AB1 2CD",
                 County = null,
-                Uprn = "123456789012",
-                LocalCustodianCode = "1435"
+                Uprn = "12345678904",
+                LocalCustodianCode = "5600"
             },
-            new Address
+            new()
             {
-                AddressLine1 = "46, The Dene",
+                AddressLine1 = "86, Test Road",
                 AddressLine2 = "",
-                Town = "Luton",
+                Town = "London",
                 Postcode = "AB1 2CD",
                 County = null,
-                Uprn = "123456789013",
-                LocalCustodianCode = "1435"
-            }
+                Uprn = "12345678905",
+                LocalCustodianCode = "5600"
+            },
+        };
+
+        // Act
+        var result = await underTest.GetAddressesAsync("AB1 2CD", "Non matching name");
+        
+        // Assert
+        result.Should().BeEquivalentTo(correctAddresses);
+    }
+    
+    [Test]
+    public async Task GetAddressesAsync_WithLpiAndDpaResults_PrefersDpaResults()
+    {
+        // Arrange
+        mockHttpHandler.Expect("http://test.com/search/places/v1/postcode?postcode=AB1%202CD")
+            .WithHeaders("Key", "testKey")
+            .Respond("application/json", DummyResponseWithMatchingLpiAndDpaData);
+
+        var correctAddresses = new List<Address>
+        {
+            new()
+            {
+                AddressLine1 = "85, Test Road Dpa",
+                AddressLine2 = "",
+                Town = "London",
+                Postcode = "AB1 2CD",
+                County = null,
+                Uprn = "12345678904",
+                LocalCustodianCode = "5600"
+            },
         };
 
         // Act
@@ -82,14 +111,14 @@ public class OsPlacesApiTests
         // Arrange
         mockHttpHandler.Expect("http://test.com/search/places/v1/postcode?postcode=AB1%202CD")
             .WithHeaders("Key", "testKey")
-            .Respond("application/json", DummyOsPlacesResponse);
+            .Respond("application/json", DummyResponseWithJustLpiData);
 
         // Act
-        var result = await underTest.GetAddressesAsync("AB1 2CD", "45");
+        var result = await underTest.GetAddressesAsync("AB1 2CD", "85");
         
         // Assert
         result.Count.Should().Be(1);
-        result.Single().AddressLine1.Should().Be("45, The Dene");
+        result.Single().AddressLine1.Should().Be("85, Test Road");
     }
     
     [Test]
@@ -98,49 +127,17 @@ public class OsPlacesApiTests
         // Arrange
         mockHttpHandler.Expect("http://test.com/search/places/v1/postcode?postcode=AB1%202CD")
             .WithHeaders("Key", "testKey")
-            .Respond("application/json", DummyOsPlacesResponse);
+            .Respond("application/json", DummyResponseWithJustLpiData);
 
         // Act
         var result = await underTest.GetAddressesAsync("AB1 2CD", "55");
         
         // Assert
         result.Count.Should().Be(2);
-        result.Should().ContainSingle(a => a.AddressLine1 == "45, The Dene");
-        result.Should().ContainSingle(a => a.AddressLine1 == "46, The Dene");
+        result.Should().ContainSingle(a => a.AddressLine1 == "85, Test Road");
+        result.Should().ContainSingle(a => a.AddressLine1 == "86, Test Road");
     }
-    
-    [Test]
-    public async Task GetAddressesAsync_CalledWithMatchingHouseName_OnlyReturnsMatch()
-    {
-        // Arrange
-        mockHttpHandler.Expect("http://test.com/search/places/v1/postcode?postcode=AB1%202CD")
-            .WithHeaders("Key", "testKey")
-            .Respond("application/json", DummyOsPlacesResponseWithNames);
 
-        // Act
-        var result = await underTest.GetAddressesAsync("AB1 2CD", "Big House");
-        
-        // Assert
-        result.Count.Should().Be(1);
-        result.Single().AddressLine1.Should().Be("Big House, The Dene");
-    }
-    
-    [Test]
-    public async Task GetAddressesAsync_CalledWithMatchingFlat_OnlyReturnsMatch()
-    {
-        // Arrange
-        mockHttpHandler.Expect("http://test.com/search/places/v1/postcode?postcode=AB1%202CD")
-            .WithHeaders("Key", "testKey")
-            .Respond("application/json", DummyOsPlacesResponseWithFlat);
-
-        // Act
-        var result = await underTest.GetAddressesAsync("AB1 2CD", "Flat 1");
-        
-        // Assert
-        result.Count.Should().Be(1);
-        result.Single().AddressLine1.Should().Be("Flat 1, Big House, The Dene");
-    }
-    
     [Test]
     public async Task GetAddressesAsync_CalledWithInvalidPostcode_ReturnsEmptyList()
     {
@@ -186,144 +183,6 @@ public class OsPlacesApiTests
     }
     
     [Test]
-    public async Task GetAddressesAsync_WhenReceivesLpiResults_TranslatesResponseIntoAddresses()
-    {
-        // Arrange
-        mockHttpHandler.Expect("http://test.com/search/places/v1/postcode?postcode=AB1%202CD")
-            .WithHeaders("Key", "testKey")
-            .Respond("application/json", DummyOsPlacesResponseWithOnlyLpiResults);
-
-        var correctAddresses = new List<Address>
-        {
-            new()
-            {
-                AddressLine1 = "Cafe, Example Studios",
-                AddressLine2 = "1–10, Example Road",
-                Town = "London",
-                Postcode = "AB1 2CD",
-                County = null,
-                Uprn = "12345678901",
-                LocalCustodianCode = "5210"
-            },
-            new()
-            {
-                AddressLine1 = "Car Parking Spaces, Example Studios",
-                AddressLine2 = "1–10, Example Road",
-                Town = "London",
-                Postcode = "AB1 2CD",
-                County = null,
-                Uprn = "12345678902",
-                LocalCustodianCode = "5210"
-            },
-            new()
-            {
-                AddressLine1 = "Example Organisation, Premises In Unit 1, Example Studios",
-                AddressLine2 = "1–10, Example Road",
-                Town = "London",
-                Postcode = "AB1 2CD",
-                County = null,
-                Uprn = "12345678903",
-                LocalCustodianCode = "5210"
-            },
-            new()
-            {
-                AddressLine1 = "Premises In Unit 2, Example Studios",
-                AddressLine2 = "1–10, Example Road",
-                Town = "London",
-                Postcode = "AB1 2CD",
-                County = null,
-                Uprn = "12345678904",
-                LocalCustodianCode = "5210"
-            },
-            new()
-            {
-                AddressLine1 = "Premises In Unit 3, Example Studios",
-                AddressLine2 = "1–10, Example Road",
-                Town = "London",
-                Postcode = "AB1 2CD",
-                County = null,
-                Uprn = "12345678905",
-                LocalCustodianCode = "5210"
-            },
-        };
-
-        // Act
-        var result = await underTest.GetAddressesAsync("AB1 2CD", "Non matching name");
-        
-        // Assert
-        result.Should().BeEquivalentTo(correctAddresses);
-    }
-    
-    [Test]
-    public async Task GetAddressesAsync_WhenReceivesDpaAndLpiResults_CorrelatesTheResultsBasedOnUprn()
-    {
-        // Arrange
-        mockHttpHandler.Expect("http://test.com/search/places/v1/postcode?postcode=AB1%202CD")
-            .WithHeaders("Key", "testKey")
-            .Respond("application/json", DummyOsPlacesResponseWithDpaAndLpiResults);
-
-        var correctAddresses = new List<Address>
-        {
-            new()
-            {
-                AddressLine1 = "Example House, Example Road",
-                AddressLine2 = "",
-                Town = "London",
-                Postcode = "AB1 2CD",
-                County = null,
-                Uprn = "12345671",
-                LocalCustodianCode = "5150"
-            },
-            new()
-            {
-                AddressLine1 = "4, Example House",
-                AddressLine2 = "Example Road",
-                Town = "London",
-                Postcode = "AB1 2CD",
-                County = null,
-                Uprn = "12345673",
-                LocalCustodianCode = "5150"
-            },
-            new()
-            {
-                AddressLine1 = "3, Example House",
-                AddressLine2 = "Example Road",
-                Town = "London",
-                Postcode = "AB1 2CD",
-                County = null,
-                Uprn = "12345674",
-                LocalCustodianCode = "5150"
-            },
-            new()
-            {
-                AddressLine1 = "2, Example House",
-                AddressLine2 = "Example Road",
-                Town = "London",
-                Postcode = "AB1 2CD",
-                County = null,
-                Uprn = "12345675",
-                LocalCustodianCode = "5150"
-            },
-            new()
-            {
-                AddressLine1 = "1, Example House",
-                AddressLine2 = "Example Road",
-                Town = "London",
-                Postcode = "AB1 2CD",
-                County = null,
-                Uprn = "12345676",
-                LocalCustodianCode = "5150"
-            },
-        };
-
-        // Act
-        var result = await underTest.GetAddressesAsync("AB1 2CD", "Non matching name");
-        
-        // Assert
-        result.Should().BeEquivalentTo(correctAddresses);
-    }
-    
-    [Test]
     public async Task GetAddressesAsync_WhenReceivesNonCurrentResidentialLpiResults_RemovesAddresses()
     {
         // Arrange
@@ -352,30 +211,159 @@ public class OsPlacesApiTests
         result.Should().BeEquivalentTo(correctAddresses);
     }
     
-
     // This is a real response from the API that has had it's data replaced with dummy values
-    private const string DummyOsPlacesResponse = @"{
-  ""header"" : {
+    private const string DummyResponseWithJustLpiData = @"{
+""header"": {
     ""uri"" : ""https://api.os.uk/search/places/v1/postcode?postcode=AB1%202CD"",
     ""query"" : ""postcode=AB1 2CD"",
     ""offset"" : 0,
-    ""totalresults"" : 10,
+    ""totalresults"" : 5,
     ""format"" : ""JSON"",
-    ""dataset"" : ""DPA"",
+    ""dataset"" : ""LPI"",
     ""lr"" : ""EN,CY"",
     ""maxresults"" : 100,
     ""epoch"" : ""101"",
     ""lastupdate"" : ""2023-05-18"",
     ""output_srs"" : ""EPSG:27700""
   },
-  ""results"" : [ {
+""results"": [
+    {
+    ""LPI"" : {
+        ""UPRN"" : ""12345678904"",
+        ""ADDRESS"" : ""85, TEST ROAD, LONDON, KENSINGTON AND CHELSEA, AB1 2CD"",
+        ""USRN"" : ""21701204"",
+        ""LPI_KEY"" : ""5600L000091363"",
+        ""PAO_START_NUMBER"" : ""85"",
+        ""STREET_DESCRIPTION"" : ""TEST ROAD"",
+        ""TOWN_NAME"" : ""LONDON"",
+        ""ADMINISTRATIVE_AREA"" : ""KENSINGTON AND CHELSEA"",
+        ""POSTCODE_LOCATOR"" : ""AB1 2CD"",
+        ""RPC"" : ""1"",
+        ""X_COORDINATE"" : 645714.0,
+        ""Y_COORDINATE"" : 789048.0,
+        ""STATUS"" : ""APPROVED"",
+        ""LOGICAL_STATUS_CODE"" : ""1"",
+        ""CLASSIFICATION_CODE"" : ""RD04"",
+        ""CLASSIFICATION_CODE_DESCRIPTION"" : ""Terraced"",
+        ""LOCAL_CUSTODIAN_CODE"" : 5600,
+        ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"" : ""KENSINGTON AND CHELSEA"",
+        ""COUNTRY_CODE"" : ""E"",
+        ""COUNTRY_CODE_DESCRIPTION"" : ""This record is within England"",
+        ""POSTAL_ADDRESS_CODE"" : ""C"",
+        ""POSTAL_ADDRESS_CODE_DESCRIPTION"" : ""A record which is postal and has a parent record which is linked to PAF"",
+        ""BLPU_STATE_CODE"" : ""2"",
+        ""BLPU_STATE_CODE_DESCRIPTION"" : ""In use"",
+        ""TOPOGRAPHY_LAYER_TOID"" : ""osgb1000049368881"",
+        ""PARENT_UPRN"" : ""217059221"",
+        ""LAST_UPDATE_DATE"" : ""22/06/2020"",
+        ""ENTRY_DATE"" : ""14/12/1990"",
+        ""BLPU_STATE_DATE"" : ""07/07/2015"",
+        ""LPI_LOGICAL_STATUS_CODE"" : ""1"",
+        ""LPI_LOGICAL_STATUS_CODE_DESCRIPTION"" : ""APPROVED"",
+        ""LANGUAGE"" : ""EN"",
+        ""MATCH"" : 1.0,
+        ""MATCH_DESCRIPTION"" : ""EXACT""
+    }
+  },
+  {
+    ""LPI"" : {
+        ""UPRN"" : ""12345678905"",
+        ""ADDRESS"" : ""86, TEST ROAD, LONDON, KENSINGTON AND CHELSEA, AB1 2CD"",
+        ""USRN"" : ""21701205"",
+        ""LPI_KEY"" : ""5600L000091364"",
+        ""PAO_START_NUMBER"" : ""86"",
+        ""STREET_DESCRIPTION"" : ""TEST ROAD"",
+        ""TOWN_NAME"" : ""LONDON"",
+        ""ADMINISTRATIVE_AREA"" : ""KENSINGTON AND CHELSEA"",
+        ""POSTCODE_LOCATOR"" : ""AB1 2CD"",
+        ""RPC"" : ""1"",
+        ""X_COORDINATE"" : 645715.0,
+        ""Y_COORDINATE"" : 789047.0,
+        ""STATUS"" : ""APPROVED"",
+        ""LOGICAL_STATUS_CODE"" : ""1"",
+        ""CLASSIFICATION_CODE"" : ""RD04"",
+        ""CLASSIFICATION_CODE_DESCRIPTION"" : ""Terraced"",
+        ""LOCAL_CUSTODIAN_CODE"" : 5600,
+        ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"" : ""KENSINGTON AND CHELSEA"",
+        ""COUNTRY_CODE"" : ""E"",
+        ""COUNTRY_CODE_DESCRIPTION"" : ""This record is within England"",
+        ""POSTAL_ADDRESS_CODE"" : ""C"",
+        ""POSTAL_ADDRESS_CODE_DESCRIPTION"" : ""A record which is postal and has a parent record which is linked to PAF"",
+        ""BLPU_STATE_CODE"" : ""2"",
+        ""BLPU_STATE_CODE_DESCRIPTION"" : ""In use"",
+        ""TOPOGRAPHY_LAYER_TOID"" : ""osgb1000049368882"",
+        ""PARENT_UPRN"" : ""217059222"",
+        ""LAST_UPDATE_DATE"" : ""22/06/2020"",
+        ""ENTRY_DATE"" : ""14/12/1990"",
+        ""BLPU_STATE_DATE"" : ""07/07/2015"",
+        ""LPI_LOGICAL_STATUS_CODE"" : ""1"",
+        ""LPI_LOGICAL_STATUS_CODE_DESCRIPTION"" : ""APPROVED"",
+        ""LANGUAGE"" : ""EN"",
+        ""MATCH"" : 1.0,
+        ""MATCH_DESCRIPTION"" : ""EXACT""
+    }
+  } ]
+}";
+    
+     private const string DummyResponseWithMatchingLpiAndDpaData = @"{
+""header"": {
+    ""uri"" : ""https://api.os.uk/search/places/v1/postcode?postcode=AB1%202CD"",
+    ""query"" : ""postcode=AB1 2CD"",
+    ""offset"" : 0,
+    ""totalresults"" : 5,
+    ""format"" : ""JSON"",
+    ""dataset"" : ""LPI"",
+    ""lr"" : ""EN,CY"",
+    ""maxresults"" : 100,
+    ""epoch"" : ""101"",
+    ""lastupdate"" : ""2023-05-18"",
+    ""output_srs"" : ""EPSG:27700""
+  },
+""results"": [
+    {
+    ""LPI"" : {
+        ""UPRN"" : ""12345678904"",
+        ""ADDRESS"" : ""85, TEST ROAD, LONDON, KENSINGTON AND CHELSEA, AB1 2CD"",
+        ""USRN"" : ""21701204"",
+        ""LPI_KEY"" : ""5600L000091363"",
+        ""PAO_START_NUMBER"" : ""85"",
+        ""STREET_DESCRIPTION"" : ""TEST ROAD"",
+        ""TOWN_NAME"" : ""LONDON"",
+        ""ADMINISTRATIVE_AREA"" : ""KENSINGTON AND CHELSEA"",
+        ""POSTCODE_LOCATOR"" : ""AB1 2CD"",
+        ""RPC"" : ""1"",
+        ""X_COORDINATE"" : 645714.0,
+        ""Y_COORDINATE"" : 789048.0,
+        ""STATUS"" : ""APPROVED"",
+        ""LOGICAL_STATUS_CODE"" : ""1"",
+        ""CLASSIFICATION_CODE"" : ""RD04"",
+        ""CLASSIFICATION_CODE_DESCRIPTION"" : ""Terraced"",
+        ""LOCAL_CUSTODIAN_CODE"" : 5600,
+        ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"" : ""KENSINGTON AND CHELSEA"",
+        ""COUNTRY_CODE"" : ""E"",
+        ""COUNTRY_CODE_DESCRIPTION"" : ""This record is within England"",
+        ""POSTAL_ADDRESS_CODE"" : ""C"",
+        ""POSTAL_ADDRESS_CODE_DESCRIPTION"" : ""A record which is postal and has a parent record which is linked to PAF"",
+        ""BLPU_STATE_CODE"" : ""2"",
+        ""BLPU_STATE_CODE_DESCRIPTION"" : ""In use"",
+        ""TOPOGRAPHY_LAYER_TOID"" : ""osgb1000049368881"",
+        ""PARENT_UPRN"" : ""217059221"",
+        ""LAST_UPDATE_DATE"" : ""22/06/2020"",
+        ""ENTRY_DATE"" : ""14/12/1990"",
+        ""BLPU_STATE_DATE"" : ""07/07/2015"",
+        ""LPI_LOGICAL_STATUS_CODE"" : ""1"",
+        ""LPI_LOGICAL_STATUS_CODE_DESCRIPTION"" : ""APPROVED"",
+        ""LANGUAGE"" : ""EN"",
+        ""MATCH"" : 1.0,
+        ""MATCH_DESCRIPTION"" : ""EXACT""
+    },
     ""DPA"" : {
-      ""UPRN"" : ""123456789012"",
+      ""UPRN"" : ""12345678904"",
       ""UDPRN"" : ""12345671"",
-      ""ADDRESS"" : ""45, THE DENE, LUTON, AB1 2CD"",
-      ""BUILDING_NUMBER"" : ""45"",
-      ""THOROUGHFARE_NAME"" : ""THE DENE"",
-      ""POST_TOWN"" : ""LUTON"",
+      ""ADDRESS"" : ""85, TEST ROAD, LONDON, KENSINGTON AND CHELSEA, AB1 2CD"",
+      ""BUILDING_NUMBER"" : ""85"",
+      ""THOROUGHFARE_NAME"" : ""TEST ROAD DPA"",
+      ""POST_TOWN"" : ""LONDON"",
       ""POSTCODE"" : ""AB1 2CD"",
       ""RPC"" : ""1"",
       ""X_COORDINATE"" : 123456.78,
@@ -384,12 +372,12 @@ public class OsPlacesApiTests
       ""LOGICAL_STATUS_CODE"" : ""1"",
       ""CLASSIFICATION_CODE"" : ""RD04"",
       ""CLASSIFICATION_CODE_DESCRIPTION"" : ""Terraced"",
-      ""LOCAL_CUSTODIAN_CODE"" : 1435,
-      ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"" : ""WEALDEN"",
+      ""LOCAL_CUSTODIAN_CODE"" : 5600,
+      ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"" : ""KENSINGTON AND CHELSEA"",
       ""COUNTRY_CODE"" : ""E"",
       ""COUNTRY_CODE_DESCRIPTION"" : ""This record is within England"",
-      ""POSTAL_ADDRESS_CODE"" : ""D"",
-      ""POSTAL_ADDRESS_CODE_DESCRIPTION"" : ""A record which is linked to PAF"",
+      ""POSTAL_ADDRESS_CODE"" : ""C"",
+      ""POSTAL_ADDRESS_CODE_DESCRIPTION"" : ""A record which is postal and has a parent record which is linked to PAF"",
       ""BLPU_STATE_CODE"" : ""2"",
       ""BLPU_STATE_CODE_DESCRIPTION"" : ""In use"",
       ""TOPOGRAPHY_LAYER_TOID"" : ""osgb1000000012345"",
@@ -401,210 +389,9 @@ public class OsPlacesApiTests
       ""MATCH_DESCRIPTION"" : ""EXACT"",
       ""DELIVERY_POINT_SUFFIX"" : ""2A""
     }
-  }, {
-    ""DPA"" : {
-      ""UPRN"" : ""123456789013"",
-      ""UDPRN"" : ""12345672"",
-      ""ADDRESS"" : ""46, THE DENE, LUTON, AB1 2CD"",
-      ""BUILDING_NUMBER"" : ""46"",
-      ""THOROUGHFARE_NAME"" : ""THE DENE"",
-      ""POST_TOWN"" : ""LUTON"",
-      ""POSTCODE"" : ""AB1 2CD"",
-      ""RPC"" : ""1"",
-      ""X_COORDINATE"" : 123457.78,
-      ""Y_COORDINATE"" : 123457.78,
-      ""STATUS"" : ""APPROVED"",
-      ""LOGICAL_STATUS_CODE"" : ""1"",
-      ""CLASSIFICATION_CODE"" : ""RD04"",
-      ""CLASSIFICATION_CODE_DESCRIPTION"" : ""Terraced"",
-      ""LOCAL_CUSTODIAN_CODE"" : 1435,
-      ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"" : ""WEALDEN"",
-      ""COUNTRY_CODE"" : ""E"",
-      ""COUNTRY_CODE_DESCRIPTION"" : ""This record is within England"",
-      ""POSTAL_ADDRESS_CODE"" : ""D"",
-      ""POSTAL_ADDRESS_CODE_DESCRIPTION"" : ""A record which is linked to PAF"",
-      ""BLPU_STATE_CODE"" : ""2"",
-      ""BLPU_STATE_CODE_DESCRIPTION"" : ""In use"",
-      ""TOPOGRAPHY_LAYER_TOID"" : ""osgb1000000012346"",
-      ""LAST_UPDATE_DATE"" : ""24/04/2016"",
-      ""ENTRY_DATE"" : ""12/11/2001"",
-      ""BLPU_STATE_DATE"" : ""07/09/2007"",
-      ""LANGUAGE"" : ""EN"",
-      ""MATCH"" : 1.0,
-      ""MATCH_DESCRIPTION"" : ""EXACT"",
-      ""DELIVERY_POINT_SUFFIX"" : ""2B""
-    }
   } ]
 }";
     
-    private const string DummyOsPlacesResponseWithNames = @"{
-  ""header"" : {
-    ""uri"" : ""https://api.os.uk/search/places/v1/postcode?postcode=AB1%202CD"",
-    ""query"" : ""postcode=AB1 2CD"",
-    ""offset"" : 0,
-    ""totalresults"" : 10,
-    ""format"" : ""JSON"",
-    ""dataset"" : ""DPA"",
-    ""lr"" : ""EN,CY"",
-    ""maxresults"" : 100,
-    ""epoch"" : ""101"",
-    ""lastupdate"" : ""2023-05-18"",
-    ""output_srs"" : ""EPSG:27700""
-  },
-  ""results"" : [ {
-    ""DPA"" : {
-      ""UPRN"" : ""123456789012"",
-      ""UDPRN"" : ""12345671"",
-      ""ADDRESS"" : ""BIG HOUSE, THE DENE, LUTON, AB1 2CD"",
-      ""BUILDING_NAME"" : ""BIG HOUSE"",
-      ""THOROUGHFARE_NAME"" : ""THE DENE"",
-      ""POST_TOWN"" : ""LUTON"",
-      ""POSTCODE"" : ""AB1 2CD"",
-      ""RPC"" : ""1"",
-      ""X_COORDINATE"" : 123456.78,
-      ""Y_COORDINATE"" : 123456.78,
-      ""STATUS"" : ""APPROVED"",
-      ""LOGICAL_STATUS_CODE"" : ""1"",
-      ""CLASSIFICATION_CODE"" : ""RD04"",
-      ""CLASSIFICATION_CODE_DESCRIPTION"" : ""Terraced"",
-      ""LOCAL_CUSTODIAN_CODE"" : 1435,
-      ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"" : ""WEALDEN"",
-      ""COUNTRY_CODE"" : ""E"",
-      ""COUNTRY_CODE_DESCRIPTION"" : ""This record is within England"",
-      ""POSTAL_ADDRESS_CODE"" : ""D"",
-      ""POSTAL_ADDRESS_CODE_DESCRIPTION"" : ""A record which is linked to PAF"",
-      ""BLPU_STATE_CODE"" : ""2"",
-      ""BLPU_STATE_CODE_DESCRIPTION"" : ""In use"",
-      ""TOPOGRAPHY_LAYER_TOID"" : ""osgb1000000012345"",
-      ""LAST_UPDATE_DATE"" : ""24/04/2016"",
-      ""ENTRY_DATE"" : ""12/11/2001"",
-      ""BLPU_STATE_DATE"" : ""07/09/2007"",
-      ""LANGUAGE"" : ""EN"",
-      ""MATCH"" : 1.0,
-      ""MATCH_DESCRIPTION"" : ""EXACT"",
-      ""DELIVERY_POINT_SUFFIX"" : ""2A""
-    }
-  }, {
-    ""DPA"" : {
-      ""UPRN"" : ""123456789013"",
-      ""UDPRN"" : ""12345672"",
-      ""ADDRESS"" : ""SMALL HOUSE, THE DENE, LUTON, AB1 2CD"",
-      ""BUILDING_NAME"" : ""SMALL HOUSE"",
-      ""THOROUGHFARE_NAME"" : ""THE DENE"",
-      ""POST_TOWN"" : ""LUTON"",
-      ""POSTCODE"" : ""AB1 2CD"",
-      ""RPC"" : ""1"",
-      ""X_COORDINATE"" : 123457.78,
-      ""Y_COORDINATE"" : 123457.78,
-      ""STATUS"" : ""APPROVED"",
-      ""LOGICAL_STATUS_CODE"" : ""1"",
-      ""CLASSIFICATION_CODE"" : ""RD04"",
-      ""CLASSIFICATION_CODE_DESCRIPTION"" : ""Terraced"",
-      ""LOCAL_CUSTODIAN_CODE"" : 1435,
-      ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"" : ""WEALDEN"",
-      ""COUNTRY_CODE"" : ""E"",
-      ""COUNTRY_CODE_DESCRIPTION"" : ""This record is within England"",
-      ""POSTAL_ADDRESS_CODE"" : ""D"",
-      ""POSTAL_ADDRESS_CODE_DESCRIPTION"" : ""A record which is linked to PAF"",
-      ""BLPU_STATE_CODE"" : ""2"",
-      ""BLPU_STATE_CODE_DESCRIPTION"" : ""In use"",
-      ""TOPOGRAPHY_LAYER_TOID"" : ""osgb1000000012346"",
-      ""LAST_UPDATE_DATE"" : ""24/04/2016"",
-      ""ENTRY_DATE"" : ""12/11/2001"",
-      ""BLPU_STATE_DATE"" : ""07/09/2007"",
-      ""LANGUAGE"" : ""EN"",
-      ""MATCH"" : 1.0,
-      ""MATCH_DESCRIPTION"" : ""EXACT"",
-      ""DELIVERY_POINT_SUFFIX"" : ""2B""
-    }
-  } ]
-}";
-    
-    
-    private const string DummyOsPlacesResponseWithFlat = @"{
-  ""header"" : {
-    ""uri"" : ""https://api.os.uk/search/places/v1/postcode?postcode=AB1%202CD"",
-    ""query"" : ""postcode=AB1 2CD"",
-    ""offset"" : 0,
-    ""totalresults"" : 10,
-    ""format"" : ""JSON"",
-    ""dataset"" : ""DPA"",
-    ""lr"" : ""EN,CY"",
-    ""maxresults"" : 100,
-    ""epoch"" : ""101"",
-    ""lastupdate"" : ""2023-05-18"",
-    ""output_srs"" : ""EPSG:27700""
-  },
-  ""results"" : [ {
-    ""DPA"" : {
-      ""UPRN"" : ""123456789012"",
-      ""UDPRN"" : ""12345671"",
-      ""ADDRESS"" : ""FLAT 1, BIG HOUSE, THE DENE, LUTON, AB1 2CD"",
-      ""SUB_BUILDING_NAME"" : ""FLAT 1"",
-      ""BUILDING_NAME"" : ""BIG HOUSE"",
-      ""THOROUGHFARE_NAME"" : ""THE DENE"",
-      ""POST_TOWN"" : ""LUTON"",
-      ""POSTCODE"" : ""AB1 2CD"",
-      ""RPC"" : ""1"",
-      ""X_COORDINATE"" : 123456.78,
-      ""Y_COORDINATE"" : 123456.78,
-      ""STATUS"" : ""APPROVED"",
-      ""LOGICAL_STATUS_CODE"" : ""1"",
-      ""CLASSIFICATION_CODE"" : ""RD04"",
-      ""CLASSIFICATION_CODE_DESCRIPTION"" : ""Terraced"",
-      ""LOCAL_CUSTODIAN_CODE"" : 1435,
-      ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"" : ""WEALDEN"",
-      ""COUNTRY_CODE"" : ""E"",
-      ""COUNTRY_CODE_DESCRIPTION"" : ""This record is within England"",
-      ""POSTAL_ADDRESS_CODE"" : ""D"",
-      ""POSTAL_ADDRESS_CODE_DESCRIPTION"" : ""A record which is linked to PAF"",
-      ""BLPU_STATE_CODE"" : ""2"",
-      ""BLPU_STATE_CODE_DESCRIPTION"" : ""In use"",
-      ""TOPOGRAPHY_LAYER_TOID"" : ""osgb1000000012345"",
-      ""LAST_UPDATE_DATE"" : ""24/04/2016"",
-      ""ENTRY_DATE"" : ""12/11/2001"",
-      ""BLPU_STATE_DATE"" : ""07/09/2007"",
-      ""LANGUAGE"" : ""EN"",
-      ""MATCH"" : 1.0,
-      ""MATCH_DESCRIPTION"" : ""EXACT"",
-      ""DELIVERY_POINT_SUFFIX"" : ""2A""
-    }
-  }, {
-    ""DPA"" : {
-      ""UPRN"" : ""123456789013"",
-      ""UDPRN"" : ""12345672"",
-      ""ADDRESS"" : ""SMALL HOUSE, THE DENE, LUTON, AB1 2CD"",
-      ""BUILDING_NAME"" : ""SMALL HOUSE"",
-      ""THOROUGHFARE_NAME"" : ""THE DENE"",
-      ""POST_TOWN"" : ""LUTON"",
-      ""POSTCODE"" : ""AB1 2CD"",
-      ""RPC"" : ""1"",
-      ""X_COORDINATE"" : 123457.78,
-      ""Y_COORDINATE"" : 123457.78,
-      ""STATUS"" : ""APPROVED"",
-      ""LOGICAL_STATUS_CODE"" : ""1"",
-      ""CLASSIFICATION_CODE"" : ""RD04"",
-      ""CLASSIFICATION_CODE_DESCRIPTION"" : ""Terraced"",
-      ""LOCAL_CUSTODIAN_CODE"" : 1435,
-      ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"" : ""WEALDEN"",
-      ""COUNTRY_CODE"" : ""E"",
-      ""COUNTRY_CODE_DESCRIPTION"" : ""This record is within England"",
-      ""POSTAL_ADDRESS_CODE"" : ""D"",
-      ""POSTAL_ADDRESS_CODE_DESCRIPTION"" : ""A record which is linked to PAF"",
-      ""BLPU_STATE_CODE"" : ""2"",
-      ""BLPU_STATE_CODE_DESCRIPTION"" : ""In use"",
-      ""TOPOGRAPHY_LAYER_TOID"" : ""osgb1000000012346"",
-      ""LAST_UPDATE_DATE"" : ""24/04/2016"",
-      ""ENTRY_DATE"" : ""12/11/2001"",
-      ""BLPU_STATE_DATE"" : ""07/09/2007"",
-      ""LANGUAGE"" : ""EN"",
-      ""MATCH"" : 1.0,
-      ""MATCH_DESCRIPTION"" : ""EXACT"",
-      ""DELIVERY_POINT_SUFFIX"" : ""2B""
-    }
-  } ]
-}";
-
     private const string DummyOsPlacesResponseWithNoResults = @"{
   ""header"" : {
     ""uri"" : ""https://api.os.uk/search/places/v1/postcode?postcode=AB1%202CD"",
@@ -620,7 +407,7 @@ public class OsPlacesApiTests
     ""output_srs"" : ""EPSG:27700""
   }
 }";
-    
+
     private const string DummyOsPlacesResponseWithMoreResults = @"{
   ""header"" : {
     ""uri"" : ""https://api.os.uk/search/places/v1/postcode?postcode=AB1%202CD"",
@@ -636,38 +423,41 @@ public class OsPlacesApiTests
     ""output_srs"" : ""EPSG:27700""
   },
   ""results"" : [ {
-    ""DPA"" : {
-      ""UPRN"" : ""123456789012"",
-      ""UDPRN"" : ""12345671"",
-      ""ADDRESS"" : ""FLAT 1, BIG HOUSE, THE DENE, LUTON, AB1 2CD"",
-      ""SUB_BUILDING_NAME"" : ""FLAT 1"",
-      ""BUILDING_NAME"" : ""BIG HOUSE"",
-      ""THOROUGHFARE_NAME"" : ""THE DENE"",
-      ""POST_TOWN"" : ""LUTON"",
-      ""POSTCODE"" : ""AB1 2CD"",
-      ""RPC"" : ""1"",
-      ""X_COORDINATE"" : 123456.78,
-      ""Y_COORDINATE"" : 123456.78,
-      ""STATUS"" : ""APPROVED"",
-      ""LOGICAL_STATUS_CODE"" : ""1"",
-      ""CLASSIFICATION_CODE"" : ""RD04"",
-      ""CLASSIFICATION_CODE_DESCRIPTION"" : ""Terraced"",
-      ""LOCAL_CUSTODIAN_CODE"" : 1435,
-      ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"" : ""WEALDEN"",
-      ""COUNTRY_CODE"" : ""E"",
-      ""COUNTRY_CODE_DESCRIPTION"" : ""This record is within England"",
-      ""POSTAL_ADDRESS_CODE"" : ""D"",
-      ""POSTAL_ADDRESS_CODE_DESCRIPTION"" : ""A record which is linked to PAF"",
-      ""BLPU_STATE_CODE"" : ""2"",
-      ""BLPU_STATE_CODE_DESCRIPTION"" : ""In use"",
-      ""TOPOGRAPHY_LAYER_TOID"" : ""osgb1000000012345"",
-      ""LAST_UPDATE_DATE"" : ""24/04/2016"",
-      ""ENTRY_DATE"" : ""12/11/2001"",
-      ""BLPU_STATE_DATE"" : ""07/09/2007"",
-      ""LANGUAGE"" : ""EN"",
-      ""MATCH"" : 1.0,
-      ""MATCH_DESCRIPTION"" : ""EXACT"",
-      ""DELIVERY_POINT_SUFFIX"" : ""2A""
+    ""LPI"" : {
+        ""UPRN"" : ""12345678904"",
+        ""ADDRESS"" : ""85, TEST ROAD, LONDON, KENSINGTON AND CHELSEA, AB1 2CD"",
+        ""USRN"" : ""21701204"",
+        ""LPI_KEY"" : ""5600L000091363"",
+        ""PAO_START_NUMBER"" : ""85"",
+        ""STREET_DESCRIPTION"" : ""TEST ROAD"",
+        ""TOWN_NAME"" : ""LONDON"",
+        ""ADMINISTRATIVE_AREA"" : ""KENSINGTON AND CHELSEA"",
+        ""POSTCODE_LOCATOR"" : ""AB1 2CD"",
+        ""RPC"" : ""1"",
+        ""X_COORDINATE"" : 645714.0,
+        ""Y_COORDINATE"" : 789048.0,
+        ""STATUS"" : ""APPROVED"",
+        ""LOGICAL_STATUS_CODE"" : ""1"",
+        ""CLASSIFICATION_CODE"" : ""RD04"",
+        ""CLASSIFICATION_CODE_DESCRIPTION"" : ""Terraced"",
+        ""LOCAL_CUSTODIAN_CODE"" : 5600,
+        ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"" : ""KENSINGTON AND CHELSEA"",
+        ""COUNTRY_CODE"" : ""E"",
+        ""COUNTRY_CODE_DESCRIPTION"" : ""This record is within England"",
+        ""POSTAL_ADDRESS_CODE"" : ""C"",
+        ""POSTAL_ADDRESS_CODE_DESCRIPTION"" : ""A record which is postal and has a parent record which is linked to PAF"",
+        ""BLPU_STATE_CODE"" : ""2"",
+        ""BLPU_STATE_CODE_DESCRIPTION"" : ""In use"",
+        ""TOPOGRAPHY_LAYER_TOID"" : ""osgb1000049368881"",
+        ""PARENT_UPRN"" : ""217059221"",
+        ""LAST_UPDATE_DATE"" : ""22/06/2020"",
+        ""ENTRY_DATE"" : ""14/12/1990"",
+        ""BLPU_STATE_DATE"" : ""07/07/2015"",
+        ""LPI_LOGICAL_STATUS_CODE"" : ""1"",
+        ""LPI_LOGICAL_STATUS_CODE_DESCRIPTION"" : ""APPROVED"",
+        ""LANGUAGE"" : ""EN"",
+        ""MATCH"" : 1.0,
+        ""MATCH_DESCRIPTION"" : ""EXACT""
     }
   } ]
 }";
@@ -687,550 +477,45 @@ public class OsPlacesApiTests
     ""output_srs"" : ""EPSG:27700""
   },
   ""results"" : [ {
-    ""DPA"" : {
-      ""UPRN"" : ""123456789013"",
-      ""UDPRN"" : ""12345672"",
-      ""ADDRESS"" : ""SMALL HOUSE, THE DENE, LUTON, AB1 2CD"",
-      ""BUILDING_NAME"" : ""SMALL HOUSE"",
-      ""THOROUGHFARE_NAME"" : ""THE DENE"",
-      ""POST_TOWN"" : ""LUTON"",
-      ""POSTCODE"" : ""AB1 2CD"",
-      ""RPC"" : ""1"",
-      ""X_COORDINATE"" : 123457.78,
-      ""Y_COORDINATE"" : 123457.78,
-      ""STATUS"" : ""APPROVED"",
-      ""LOGICAL_STATUS_CODE"" : ""1"",
-      ""CLASSIFICATION_CODE"" : ""RD04"",
-      ""CLASSIFICATION_CODE_DESCRIPTION"" : ""Terraced"",
-      ""LOCAL_CUSTODIAN_CODE"" : 1435,
-      ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"" : ""WEALDEN"",
-      ""COUNTRY_CODE"" : ""E"",
-      ""COUNTRY_CODE_DESCRIPTION"" : ""This record is within England"",
-      ""POSTAL_ADDRESS_CODE"" : ""D"",
-      ""POSTAL_ADDRESS_CODE_DESCRIPTION"" : ""A record which is linked to PAF"",
-      ""BLPU_STATE_CODE"" : ""2"",
-      ""BLPU_STATE_CODE_DESCRIPTION"" : ""In use"",
-      ""TOPOGRAPHY_LAYER_TOID"" : ""osgb1000000012346"",
-      ""LAST_UPDATE_DATE"" : ""24/04/2016"",
-      ""ENTRY_DATE"" : ""12/11/2001"",
-      ""BLPU_STATE_DATE"" : ""07/09/2007"",
-      ""LANGUAGE"" : ""EN"",
-      ""MATCH"" : 1.0,
-      ""MATCH_DESCRIPTION"" : ""EXACT"",
-      ""DELIVERY_POINT_SUFFIX"" : ""2B""
+    ""LPI"" : {
+        ""UPRN"" : ""12345678905"",
+        ""ADDRESS"" : ""86, TEST ROAD, LONDON, KENSINGTON AND CHELSEA, AB1 2CD"",
+        ""USRN"" : ""21701205"",
+        ""LPI_KEY"" : ""5600L000091364"",
+        ""PAO_START_NUMBER"" : ""86"",
+        ""STREET_DESCRIPTION"" : ""TEST ROAD"",
+        ""TOWN_NAME"" : ""LONDON"",
+        ""ADMINISTRATIVE_AREA"" : ""KENSINGTON AND CHELSEA"",
+        ""POSTCODE_LOCATOR"" : ""AB1 2CD"",
+        ""RPC"" : ""1"",
+        ""X_COORDINATE"" : 645715.0,
+        ""Y_COORDINATE"" : 789047.0,
+        ""STATUS"" : ""APPROVED"",
+        ""LOGICAL_STATUS_CODE"" : ""1"",
+        ""CLASSIFICATION_CODE"" : ""RD04"",
+        ""CLASSIFICATION_CODE_DESCRIPTION"" : ""Terraced"",
+        ""LOCAL_CUSTODIAN_CODE"" : 5600,
+        ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"" : ""KENSINGTON AND CHELSEA"",
+        ""COUNTRY_CODE"" : ""E"",
+        ""COUNTRY_CODE_DESCRIPTION"" : ""This record is within England"",
+        ""POSTAL_ADDRESS_CODE"" : ""C"",
+        ""POSTAL_ADDRESS_CODE_DESCRIPTION"" : ""A record which is postal and has a parent record which is linked to PAF"",
+        ""BLPU_STATE_CODE"" : ""2"",
+        ""BLPU_STATE_CODE_DESCRIPTION"" : ""In use"",
+        ""TOPOGRAPHY_LAYER_TOID"" : ""osgb1000049368882"",
+        ""PARENT_UPRN"" : ""217059222"",
+        ""LAST_UPDATE_DATE"" : ""22/06/2020"",
+        ""ENTRY_DATE"" : ""14/12/1990"",
+        ""BLPU_STATE_DATE"" : ""07/07/2015"",
+        ""LPI_LOGICAL_STATUS_CODE"" : ""1"",
+        ""LPI_LOGICAL_STATUS_CODE_DESCRIPTION"" : ""APPROVED"",
+        ""LANGUAGE"" : ""EN"",
+        ""MATCH"" : 1.0,
+        ""MATCH_DESCRIPTION"" : ""EXACT""
     }
   } ]
 }";
-    
-    private const string DummyOsPlacesResponseWithOnlyLpiResults = @"{
-    ""header"": {
-        ""uri"" : ""https://api.os.uk/search/places/v1/postcode?postcode=AB1%202CD"",
-        ""query"" : ""postcode=AB1 2CD"",
-        ""offset"" : 0,
-        ""totalresults"" : 5,
-        ""format"" : ""JSON"",
-        ""dataset"" : ""LPI"",
-        ""lr"" : ""EN,CY"",
-        ""maxresults"" : 100,
-        ""epoch"" : ""101"",
-        ""lastupdate"" : ""2023-05-18"",
-        ""output_srs"" : ""EPSG:27700""
-      },
-    ""results"": [
-        {
-            ""LPI"": {
-                ""UPRN"": ""12345678901"",
-                ""ADDRESS"": ""CAFE, EXAMPLE STUDIOS, 1-10, EXAMPLE ROAD, LONDON, CAMDEN, AB1 2CD"",
-                ""USRN"": ""9876543"",
-                ""LPI_KEY"": ""5150L000099999"",
-                ""SAO_TEXT"": ""CAFE"",
-                ""PAO_START_NUMBER"": ""1"",
-                ""PAO_END_NUMBER"": ""10"",
-                ""PAO_TEXT"": ""EXAMPLE STUDIOS"",
-                ""STREET_DESCRIPTION"": ""EXAMPLE ROAD"",
-                ""TOWN_NAME"": ""LONDON"",
-                ""ADMINISTRATIVE_AREA"": ""CAMDEN"",
-                ""POSTCODE_LOCATOR"": ""AB1 2CD"",
-                ""RPC"": ""2"",
-                ""X_COORDINATE"": 1234567.78,
-                ""Y_COORDINATE"": 1234567.78,
-                ""STATUS"": ""APPROVED"",
-                ""LOGICAL_STATUS_CODE"": ""1"",
-                ""CLASSIFICATION_CODE"": ""RD07"",
-                ""CLASSIFICATION_CODE_DESCRIPTION"": ""Restaurant / Cafeteria"",
-                ""LOCAL_CUSTODIAN_CODE"": 5210,
-                ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""CAMDEN"",
-                ""COUNTRY_CODE"": ""E"",
-                ""COUNTRY_CODE_DESCRIPTION"": ""This record is within England"",
-                ""POSTAL_ADDRESS_CODE"": ""C"",
-                ""POSTAL_ADDRESS_CODE_DESCRIPTION"": ""A record which is postal and has a parent record which is linked to PAF"",
-                ""BLPU_STATE_CODE"": ""2"",
-                ""BLPU_STATE_CODE_DESCRIPTION"": ""In use"",
-                ""TOPOGRAPHY_LAYER_TOID"": ""osgb1000000000000"",
-                ""PARENT_UPRN"": ""9090909"",
-                ""LAST_UPDATE_DATE"": ""25/03/2022"",
-                ""ENTRY_DATE"": ""08/10/2002"",
-                ""BLPU_STATE_DATE"": ""08/10/2002"",
-                ""STREET_STATE_CODE"": ""2"",
-                ""STREET_STATE_CODE_DESCRIPTION"": ""Open"",
-                ""STREET_CLASSIFICATION_CODE"": ""8"",
-                ""STREET_CLASSIFICATION_CODE_DESCRIPTION"": ""All vehicles"",
-                ""LPI_LOGICAL_STATUS_CODE"": ""1"",
-                ""LPI_LOGICAL_STATUS_CODE_DESCRIPTION"": ""APPROVED"",
-                ""LANGUAGE"": ""EN"",
-                ""MATCH"": 1.0,
-                ""MATCH_DESCRIPTION"": ""EXACT""
-            }
-        },
-        {
-            ""LPI"": {
-                ""UPRN"": ""12345678902"",
-                ""ADDRESS"": ""CAR PARKING SPACES, EXAMPLE STUDIOS, 1-10, EXAMPLE ROAD, LONDON, CAMDEN, AB1 2CD"",
-                ""USRN"": ""9876543"",
-                ""LPI_KEY"": ""5150L000099999"",
-                ""SAO_TEXT"": ""CAR PARKING SPACES"",
-                ""PAO_START_NUMBER"": ""1"",
-                ""PAO_END_NUMBER"": ""10"",
-                ""PAO_TEXT"": ""EXAMPLE STUDIOS"",
-                ""STREET_DESCRIPTION"": ""EXAMPLE ROAD"",
-                ""TOWN_NAME"": ""LONDON"",
-                ""ADMINISTRATIVE_AREA"": ""CAMDEN"",
-                ""POSTCODE_LOCATOR"": ""AB1 2CD"",
-                ""RPC"": ""2"",
-                ""X_COORDINATE"": 1234567.78,
-                ""Y_COORDINATE"": 1234567.78,
-                ""STATUS"": ""APPROVED"",
-                ""LOGICAL_STATUS_CODE"": ""1"",
-                ""CLASSIFICATION_CODE"": ""RD01"",
-                ""CLASSIFICATION_CODE_DESCRIPTION"": ""Commercial"",
-                ""LOCAL_CUSTODIAN_CODE"": 5210,
-                ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""CAMDEN"",
-                ""COUNTRY_CODE"": ""E"",
-                ""COUNTRY_CODE_DESCRIPTION"": ""This record is within England"",
-                ""POSTAL_ADDRESS_CODE"": ""C"",
-                ""POSTAL_ADDRESS_CODE_DESCRIPTION"": ""A record which is postal and has a parent record which is linked to PAF"",
-                ""BLPU_STATE_CODE"": ""2"",
-                ""BLPU_STATE_CODE_DESCRIPTION"": ""In use"",
-                ""TOPOGRAPHY_LAYER_TOID"": ""osgb1000000000000"",
-                ""PARENT_UPRN"": ""9090909"",
-                ""LAST_UPDATE_DATE"": ""25/03/2022"",
-                ""ENTRY_DATE"": ""08/10/2002"",
-                ""BLPU_STATE_DATE"": ""08/10/2002"",
-                ""STREET_STATE_CODE"": ""2"",
-                ""STREET_STATE_CODE_DESCRIPTION"": ""Open"",
-                ""STREET_CLASSIFICATION_CODE"": ""8"",
-                ""STREET_CLASSIFICATION_CODE_DESCRIPTION"": ""All vehicles"",
-                ""LPI_LOGICAL_STATUS_CODE"": ""1"",
-                ""LPI_LOGICAL_STATUS_CODE_DESCRIPTION"": ""APPROVED"",
-                ""LANGUAGE"": ""EN"",
-                ""MATCH"": 1.0,
-                ""MATCH_DESCRIPTION"": ""EXACT""
-            }
-        },
-        {
-            ""LPI"": {
-                ""UPRN"": ""12345678903"",
-                ""ADDRESS"": ""EXAMPLE ORGANISATION, PREMISES IN UNIT 1, EXAMPLE STUDIOS, 1-10, EXAMPLE ROAD, LONDON, CAMDEN, AB1 2CD"",
-                ""USRN"": ""9876543"",
-                ""LPI_KEY"": ""5150L000099999"",
-                ""ORGANISATION"": ""EXAMPLE ORGANISATION"",
-                ""SAO_TEXT"": ""PREMISES IN UNIT 1"",
-                ""PAO_START_NUMBER"": ""1"",
-                ""PAO_END_NUMBER"": ""10"",
-                ""PAO_TEXT"": ""EXAMPLE STUDIOS"",
-                ""STREET_DESCRIPTION"": ""EXAMPLE ROAD"",
-                ""TOWN_NAME"": ""LONDON"",
-                ""ADMINISTRATIVE_AREA"": ""CAMDEN"",
-                ""POSTCODE_LOCATOR"": ""AB1 2CD"",
-                ""RPC"": ""2"",
-                ""X_COORDINATE"": 1234567.78,
-                ""Y_COORDINATE"": 1234567.78,
-                ""STATUS"": ""APPROVED"",
-                ""LOGICAL_STATUS_CODE"": ""1"",
-                ""CLASSIFICATION_CODE"": ""RD06"",
-                ""CLASSIFICATION_CODE_DESCRIPTION"": ""Indoor / Outdoor Leisure / Sporting Activity / Centre"",
-                ""LOCAL_CUSTODIAN_CODE"": 5210,
-                ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""CAMDEN"",
-                ""COUNTRY_CODE"": ""E"",
-                ""COUNTRY_CODE_DESCRIPTION"": ""This record is within England"",
-                ""POSTAL_ADDRESS_CODE"": ""D"",
-                ""POSTAL_ADDRESS_CODE_DESCRIPTION"": ""A record which is linked to PAF"",
-                ""BLPU_STATE_CODE"": ""2"",
-                ""BLPU_STATE_CODE_DESCRIPTION"": ""In use"",
-                ""TOPOGRAPHY_LAYER_TOID"": ""osgb1000000000000"",
-                ""PARENT_UPRN"": ""9090909"",
-                ""LAST_UPDATE_DATE"": ""25/03/2022"",
-                ""ENTRY_DATE"": ""08/10/2002"",
-                ""BLPU_STATE_DATE"": ""08/10/2002"",
-                ""STREET_STATE_CODE"": ""2"",
-                ""STREET_STATE_CODE_DESCRIPTION"": ""Open"",
-                ""STREET_CLASSIFICATION_CODE"": ""8"",
-                ""STREET_CLASSIFICATION_CODE_DESCRIPTION"": ""All vehicles"",
-                ""LPI_LOGICAL_STATUS_CODE"": ""1"",
-                ""LPI_LOGICAL_STATUS_CODE_DESCRIPTION"": ""APPROVED"",
-                ""LANGUAGE"": ""EN"",
-                ""MATCH"": 1.0,
-                ""MATCH_DESCRIPTION"": ""EXACT""
-            }
-        },
-        {
-            ""LPI"": {
-                ""UPRN"": ""12345678904"",
-                ""ADDRESS"": ""PREMISES IN UNIT 2, EXAMPLE STUDIOS, 1-10, EXAMPLE ROAD, LONDON, CAMDEN, AB1 2CD"",
-                ""USRN"": ""9876543"",
-                ""LPI_KEY"": ""5150L000099999"",
-                ""SAO_TEXT"": ""PREMISES IN UNIT 2"",
-                ""PAO_START_NUMBER"": ""1"",
-                ""PAO_END_NUMBER"": ""10"",
-                ""PAO_TEXT"": ""EXAMPLE STUDIOS"",
-                ""STREET_DESCRIPTION"": ""EXAMPLE ROAD"",
-                ""TOWN_NAME"": ""LONDON"",
-                ""ADMINISTRATIVE_AREA"": ""CAMDEN"",
-                ""POSTCODE_LOCATOR"": ""AB1 2CD"",
-                ""RPC"": ""2"",
-                ""X_COORDINATE"": 1234567.78,
-                ""Y_COORDINATE"": 1234567.78,
-                ""STATUS"": ""APPROVED"",
-                ""LOGICAL_STATUS_CODE"": ""1"",
-                ""CLASSIFICATION_CODE"": ""RD02"",
-                ""CLASSIFICATION_CODE_DESCRIPTION"": ""Children’s Nursery / Crèche"",
-                ""LOCAL_CUSTODIAN_CODE"": 5210,
-                ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""CAMDEN"",
-                ""COUNTRY_CODE"": ""E"",
-                ""COUNTRY_CODE_DESCRIPTION"": ""This record is within England"",
-                ""POSTAL_ADDRESS_CODE"": ""C"",
-                ""POSTAL_ADDRESS_CODE_DESCRIPTION"": ""A record which is postal and has a parent record which is linked to PAF"",
-                ""BLPU_STATE_CODE"": ""2"",
-                ""BLPU_STATE_CODE_DESCRIPTION"": ""In use"",
-                ""TOPOGRAPHY_LAYER_TOID"": ""osgb1000000000000"",
-                ""PARENT_UPRN"": ""9090909"",
-                ""LAST_UPDATE_DATE"": ""25/03/2022"",
-                ""ENTRY_DATE"": ""08/10/2002"",
-                ""BLPU_STATE_DATE"": ""08/10/2002"",
-                ""STREET_STATE_CODE"": ""2"",
-                ""STREET_STATE_CODE_DESCRIPTION"": ""Open"",
-                ""STREET_CLASSIFICATION_CODE"": ""8"",
-                ""STREET_CLASSIFICATION_CODE_DESCRIPTION"": ""All vehicles"",
-                ""LPI_LOGICAL_STATUS_CODE"": ""1"",
-                ""LPI_LOGICAL_STATUS_CODE_DESCRIPTION"": ""APPROVED"",
-                ""LANGUAGE"": ""EN"",
-                ""MATCH"": 1.0,
-                ""MATCH_DESCRIPTION"": ""EXACT""
-            }
-        },
-        {
-            ""LPI"": {
-                ""UPRN"": ""12345678905"",
-                ""ADDRESS"": ""PREMISES IN UNIT 3, EXAMPLE STUDIOS, 1-10, EXAMPLE ROAD, LONDON, CAMDEN, AB1 2CD"",
-                ""USRN"": ""9876543"",
-                ""LPI_KEY"": ""5150L000099999"",
-                ""SAO_TEXT"": ""PREMISES IN UNIT 3"",
-                ""PAO_START_NUMBER"": ""1"",
-                ""PAO_END_NUMBER"": ""10"",
-                ""PAO_TEXT"": ""EXAMPLE STUDIOS"",
-                ""STREET_DESCRIPTION"": ""EXAMPLE ROAD"",
-                ""TOWN_NAME"": ""LONDON"",
-                ""ADMINISTRATIVE_AREA"": ""CAMDEN"",
-                ""POSTCODE_LOCATOR"": ""AB1 2CD"",
-                ""RPC"": ""2"",
-                ""X_COORDINATE"": 1234567.78,
-                ""Y_COORDINATE"": 1234567.78,
-                ""STATUS"": ""APPROVED"",
-                ""LOGICAL_STATUS_CODE"": ""1"",
-                ""CLASSIFICATION_CODE"": ""RD01"",
-                ""CLASSIFICATION_CODE_DESCRIPTION"": ""Office / Work Studio"",
-                ""LOCAL_CUSTODIAN_CODE"": 5210,
-                ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""CAMDEN"",
-                ""COUNTRY_CODE"": ""E"",
-                ""COUNTRY_CODE_DESCRIPTION"": ""This record is within England"",
-                ""POSTAL_ADDRESS_CODE"": ""C"",
-                ""POSTAL_ADDRESS_CODE_DESCRIPTION"": ""A record which is postal and has a parent record which is linked to PAF"",
-                ""BLPU_STATE_CODE"": ""2"",
-                ""BLPU_STATE_CODE_DESCRIPTION"": ""In use"",
-                ""TOPOGRAPHY_LAYER_TOID"": ""osgb1000000000000"",
-                ""PARENT_UPRN"": ""9090909"",
-                ""LAST_UPDATE_DATE"": ""25/03/2022"",
-                ""ENTRY_DATE"": ""16/10/2012"",
-                ""BLPU_STATE_DATE"": ""16/10/2012"",
-                ""STREET_STATE_CODE"": ""2"",
-                ""STREET_STATE_CODE_DESCRIPTION"": ""Open"",
-                ""STREET_CLASSIFICATION_CODE"": ""8"",
-                ""STREET_CLASSIFICATION_CODE_DESCRIPTION"": ""All vehicles"",
-                ""LPI_LOGICAL_STATUS_CODE"": ""1"",
-                ""LPI_LOGICAL_STATUS_CODE_DESCRIPTION"": ""APPROVED"",
-                ""LANGUAGE"": ""EN"",
-                ""MATCH"": 1.0,
-                ""MATCH_DESCRIPTION"": ""EXACT""
-            }
-        }
-    ]
-}";
-    
-    private const string DummyOsPlacesResponseWithDpaAndLpiResults = @"{
-    ""header"": {
-        ""uri"": ""https://api.os.uk/search/places/v1/postcode?postcode=AB1%202CD&lr=EN&dataset=LPI%2CDPA"",
-        ""query"": ""postcode=AB1 2CD"",
-        ""offset"": 0,
-        ""totalresults"": 6,
-        ""format"": ""JSON"",
-        ""dataset"": ""LPI,DPA"",
-        ""lr"": ""EN"",
-        ""maxresults"": 100,
-        ""epoch"": ""102"",
-        ""lastupdate"": ""2023-06-22"",
-        ""output_srs"": ""EPSG:27700""
-    },
-    ""results"": [
-        {
-            ""DPA"": {
-                ""UPRN"": ""12345671"",
-                ""UDPRN"": ""12345671"",
-                ""ADDRESS"": ""EXAMPLE HOUSE, EXAMPLE ROAD, LONDON, AB1 2CD"",
-                ""BUILDING_NAME"": ""EXAMPLE HOUSE"",
-                ""THOROUGHFARE_NAME"": ""EXAMPLE ROAD"",
-                ""POST_TOWN"": ""LONDON"",
-                ""POSTCODE"": ""AB1 2CD"",
-                ""RPC"": ""2"",
-                ""X_COORDINATE"": 1234567.78,
-                ""Y_COORDINATE"": 1234567.78,
-                ""STATUS"": ""APPROVED"",
-                ""LOGICAL_STATUS_CODE"": ""1"",
-                ""CLASSIFICATION_CODE"": ""RD01"",
-                ""CLASSIFICATION_CODE_DESCRIPTION"": ""Property Shell"",
-                ""LOCAL_CUSTODIAN_CODE"": 5150,
-                ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""BRENT"",
-                ""COUNTRY_CODE"": ""E"",
-                ""COUNTRY_CODE_DESCRIPTION"": ""This record is within England"",
-                ""POSTAL_ADDRESS_CODE"": ""D"",
-                ""POSTAL_ADDRESS_CODE_DESCRIPTION"": ""A record which is linked to PAF"",
-                ""BLPU_STATE_CODE"": ""2"",
-                ""BLPU_STATE_CODE_DESCRIPTION"": ""In use"",
-                ""TOPOGRAPHY_LAYER_TOID"": ""osgb1000009999999"",
-                ""LAST_UPDATE_DATE"": ""30/07/2017"",
-                ""ENTRY_DATE"": ""18/09/2007"",
-                ""BLPU_STATE_DATE"": ""01/04/2009"",
-                ""LANGUAGE"": ""EN"",
-                ""MATCH"": 1.0,
-                ""MATCH_DESCRIPTION"": ""EXACT"",
-                ""DELIVERY_POINT_SUFFIX"": ""1A""
-            }
-        },
-        {
-            ""LPI"": {
-                ""UPRN"": ""12345673"",
-                ""ADDRESS"": ""4, EXAMPLE HOUSE, EXAMPLE ROAD, LONDON, BRENT, AB1 2CD"",
-                ""USRN"": ""9876543"",
-                ""LPI_KEY"": ""5150L000099999"",
-                ""SAO_START_NUMBER"": ""4"",
-                ""PAO_TEXT"": ""EXAMPLE HOUSE"",
-                ""STREET_DESCRIPTION"": ""EXAMPLE ROAD"",
-                ""TOWN_NAME"": ""LONDON"",
-                ""ADMINISTRATIVE_AREA"": ""BRENT"",
-                ""POSTCODE_LOCATOR"": ""AB1 2CD"",
-                ""RPC"": ""2"",
-                ""X_COORDINATE"": 1234567.78,
-                ""Y_COORDINATE"": 1234567.78,
-                ""STATUS"": ""APPROVED"",
-                ""LOGICAL_STATUS_CODE"": ""1"",
-                ""CLASSIFICATION_CODE"": ""RD06"",
-                ""CLASSIFICATION_CODE_DESCRIPTION"": ""Self Contained Flat (Includes Maisonette / Apartment)"",
-                ""LOCAL_CUSTODIAN_CODE"": 5150,
-                ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""BRENT"",
-                ""COUNTRY_CODE"": ""E"",
-                ""COUNTRY_CODE_DESCRIPTION"": ""This record is within England"",
-                ""POSTAL_ADDRESS_CODE"": ""C"",
-                ""POSTAL_ADDRESS_CODE_DESCRIPTION"": ""A record which is postal and has a parent record which is linked to PAF"",
-                ""BLPU_STATE_CODE"": ""2"",
-                ""BLPU_STATE_CODE_DESCRIPTION"": ""In use"",
-                ""TOPOGRAPHY_LAYER_TOID"": ""osgb1000009999999"",
-                ""PARENT_UPRN"": ""12345671"",
-                ""LAST_UPDATE_DATE"": ""30/07/2017"",
-                ""ENTRY_DATE"": ""17/09/1979"",
-                ""BLPU_STATE_DATE"": ""10/08/2007"",
-                ""STREET_STATE_CODE"": ""2"",
-                ""STREET_STATE_CODE_DESCRIPTION"": ""Open"",
-                ""STREET_CLASSIFICATION_CODE"": ""8"",
-                ""STREET_CLASSIFICATION_CODE_DESCRIPTION"": ""All vehicles"",
-                ""LPI_LOGICAL_STATUS_CODE"": ""1"",
-                ""LPI_LOGICAL_STATUS_CODE_DESCRIPTION"": ""APPROVED"",
-                ""LANGUAGE"": ""EN"",
-                ""MATCH"": 1.0,
-                ""MATCH_DESCRIPTION"": ""EXACT""
-            }
-        },
-        {
-            ""LPI"": {
-                ""UPRN"": ""12345674"",
-                ""ADDRESS"": ""3, EXAMPLE HOUSE, EXAMPLE ROAD, LONDON, BRENT, AB1 2CD"",
-                ""USRN"": ""9876543"",
-                ""LPI_KEY"": ""5150L000099999"",
-                ""SAO_START_NUMBER"": ""3"",
-                ""PAO_TEXT"": ""EXAMPLE HOUSE"",
-                ""STREET_DESCRIPTION"": ""EXAMPLE ROAD"",
-                ""TOWN_NAME"": ""LONDON"",
-                ""ADMINISTRATIVE_AREA"": ""BRENT"",
-                ""POSTCODE_LOCATOR"": ""AB1 2CD"",
-                ""RPC"": ""2"",
-                ""X_COORDINATE"": 1234567.78,
-                ""Y_COORDINATE"": 1234567.78,
-                ""STATUS"": ""APPROVED"",
-                ""LOGICAL_STATUS_CODE"": ""1"",
-                ""CLASSIFICATION_CODE"": ""RD06"",
-                ""CLASSIFICATION_CODE_DESCRIPTION"": ""Self Contained Flat (Includes Maisonette / Apartment)"",
-                ""LOCAL_CUSTODIAN_CODE"": 5150,
-                ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""BRENT"",
-                ""COUNTRY_CODE"": ""E"",
-                ""COUNTRY_CODE_DESCRIPTION"": ""This record is within England"",
-                ""POSTAL_ADDRESS_CODE"": ""C"",
-                ""POSTAL_ADDRESS_CODE_DESCRIPTION"": ""A record which is postal and has a parent record which is linked to PAF"",
-                ""BLPU_STATE_CODE"": ""2"",
-                ""BLPU_STATE_CODE_DESCRIPTION"": ""In use"",
-                ""TOPOGRAPHY_LAYER_TOID"": ""osgb1000009999999"",
-                ""PARENT_UPRN"": ""12345671"",
-                ""LAST_UPDATE_DATE"": ""30/07/2017"",
-                ""ENTRY_DATE"": ""17/09/1979"",
-                ""BLPU_STATE_DATE"": ""10/08/2007"",
-                ""STREET_STATE_CODE"": ""2"",
-                ""STREET_STATE_CODE_DESCRIPTION"": ""Open"",
-                ""STREET_CLASSIFICATION_CODE"": ""8"",
-                ""STREET_CLASSIFICATION_CODE_DESCRIPTION"": ""All vehicles"",
-                ""LPI_LOGICAL_STATUS_CODE"": ""1"",
-                ""LPI_LOGICAL_STATUS_CODE_DESCRIPTION"": ""APPROVED"",
-                ""LANGUAGE"": ""EN"",
-                ""MATCH"": 1.0,
-                ""MATCH_DESCRIPTION"": ""EXACT""
-            }
-        },
-        {
-            ""LPI"": {
-                ""UPRN"": ""12345675"",
-                ""ADDRESS"": ""2, EXAMPLE HOUSE, EXAMPLE ROAD, LONDON, BRENT, AB1 2CD"",
-                ""USRN"": ""9876543"",
-                ""LPI_KEY"": ""5150L000099999"",
-                ""SAO_START_NUMBER"": ""2"",
-                ""PAO_TEXT"": ""EXAMPLE HOUSE"",
-                ""STREET_DESCRIPTION"": ""EXAMPLE ROAD"",
-                ""TOWN_NAME"": ""LONDON"",
-                ""ADMINISTRATIVE_AREA"": ""BRENT"",
-                ""POSTCODE_LOCATOR"": ""AB1 2CD"",
-                ""RPC"": ""2"",
-                ""X_COORDINATE"": 1234567.78,
-                ""Y_COORDINATE"": 1234567.78,
-                ""STATUS"": ""APPROVED"",
-                ""LOGICAL_STATUS_CODE"": ""1"",
-                ""CLASSIFICATION_CODE"": ""RD06"",
-                ""CLASSIFICATION_CODE_DESCRIPTION"": ""Self Contained Flat (Includes Maisonette / Apartment)"",
-                ""LOCAL_CUSTODIAN_CODE"": 5150,
-                ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""BRENT"",
-                ""COUNTRY_CODE"": ""E"",
-                ""COUNTRY_CODE_DESCRIPTION"": ""This record is within England"",
-                ""POSTAL_ADDRESS_CODE"": ""C"",
-                ""POSTAL_ADDRESS_CODE_DESCRIPTION"": ""A record which is postal and has a parent record which is linked to PAF"",
-                ""BLPU_STATE_CODE"": ""2"",
-                ""BLPU_STATE_CODE_DESCRIPTION"": ""In use"",
-                ""TOPOGRAPHY_LAYER_TOID"": ""osgb1000009999999"",
-                ""PARENT_UPRN"": ""12345671"",
-                ""LAST_UPDATE_DATE"": ""30/07/2017"",
-                ""ENTRY_DATE"": ""17/09/1979"",
-                ""BLPU_STATE_DATE"": ""10/08/2007"",
-                ""STREET_STATE_CODE"": ""2"",
-                ""STREET_STATE_CODE_DESCRIPTION"": ""Open"",
-                ""STREET_CLASSIFICATION_CODE"": ""8"",
-                ""STREET_CLASSIFICATION_CODE_DESCRIPTION"": ""All vehicles"",
-                ""LPI_LOGICAL_STATUS_CODE"": ""1"",
-                ""LPI_LOGICAL_STATUS_CODE_DESCRIPTION"": ""APPROVED"",
-                ""LANGUAGE"": ""EN"",
-                ""MATCH"": 1.0,
-                ""MATCH_DESCRIPTION"": ""EXACT""
-            }
-        },
-        {
-            ""LPI"": {
-                ""UPRN"": ""12345676"",
-                ""ADDRESS"": ""1, EXAMPLE HOUSE, EXAMPLE ROAD, LONDON, BRENT, AB1 2CD"",
-                ""USRN"": ""9876543"",
-                ""LPI_KEY"": ""5150L000099999"",
-                ""SAO_START_NUMBER"": ""1"",
-                ""PAO_TEXT"": ""EXAMPLE HOUSE"",
-                ""STREET_DESCRIPTION"": ""EXAMPLE ROAD"",
-                ""TOWN_NAME"": ""LONDON"",
-                ""ADMINISTRATIVE_AREA"": ""BRENT"",
-                ""POSTCODE_LOCATOR"": ""AB1 2CD"",
-                ""RPC"": ""2"",
-                ""X_COORDINATE"": 1234567.78,
-                ""Y_COORDINATE"": 1234567.78,
-                ""STATUS"": ""APPROVED"",
-                ""LOGICAL_STATUS_CODE"": ""1"",
-                ""CLASSIFICATION_CODE"": ""RD06"",
-                ""CLASSIFICATION_CODE_DESCRIPTION"": ""Self Contained Flat (Includes Maisonette / Apartment)"",
-                ""LOCAL_CUSTODIAN_CODE"": 5150,
-                ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""BRENT"",
-                ""COUNTRY_CODE"": ""E"",
-                ""COUNTRY_CODE_DESCRIPTION"": ""This record is within England"",
-                ""POSTAL_ADDRESS_CODE"": ""C"",
-                ""POSTAL_ADDRESS_CODE_DESCRIPTION"": ""A record which is postal and has a parent record which is linked to PAF"",
-                ""BLPU_STATE_CODE"": ""2"",
-                ""BLPU_STATE_CODE_DESCRIPTION"": ""In use"",
-                ""TOPOGRAPHY_LAYER_TOID"": ""osgb1000009999999"",
-                ""PARENT_UPRN"": ""12345671"",
-                ""LAST_UPDATE_DATE"": ""30/07/2017"",
-                ""ENTRY_DATE"": ""17/09/1979"",
-                ""BLPU_STATE_DATE"": ""10/08/2007"",
-                ""STREET_STATE_CODE"": ""2"",
-                ""STREET_STATE_CODE_DESCRIPTION"": ""Open"",
-                ""STREET_CLASSIFICATION_CODE"": ""8"",
-                ""STREET_CLASSIFICATION_CODE_DESCRIPTION"": ""All vehicles"",
-                ""LPI_LOGICAL_STATUS_CODE"": ""1"",
-                ""LPI_LOGICAL_STATUS_CODE_DESCRIPTION"": ""APPROVED"",
-                ""LANGUAGE"": ""EN"",
-                ""MATCH"": 1.0,
-                ""MATCH_DESCRIPTION"": ""EXACT""
-            }
-        },
-        {
-            ""LPI"": {
-                ""UPRN"": ""12345671"",
-                ""ADDRESS"": ""EXAMPLE HOUSE, EXAMPLE ROAD, LONDON, BRENT, AB1 2CD"",
-                ""USRN"": ""9876543"",
-                ""LPI_KEY"": ""5150L000099999"",
-                ""PAO_TEXT"": ""EXAMPLE HOUSE"",
-                ""STREET_DESCRIPTION"": ""EXAMPLE ROAD"",
-                ""TOWN_NAME"": ""LONDON"",
-                ""ADMINISTRATIVE_AREA"": ""BRENT"",
-                ""POSTCODE_LOCATOR"": ""AB1 2CD"",
-                ""RPC"": ""2"",
-                ""X_COORDINATE"": 1234567.78,
-                ""Y_COORDINATE"": 1234567.78,
-                ""STATUS"": ""APPROVED"",
-                ""LOGICAL_STATUS_CODE"": ""1"",
-                ""CLASSIFICATION_CODE"": ""PP"",
-                ""CLASSIFICATION_CODE_DESCRIPTION"": ""Property Shell"",
-                ""LOCAL_CUSTODIAN_CODE"": 5150,
-                ""LOCAL_CUSTODIAN_CODE_DESCRIPTION"": ""BRENT"",
-                ""COUNTRY_CODE"": ""E"",
-                ""COUNTRY_CODE_DESCRIPTION"": ""This record is within England"",
-                ""POSTAL_ADDRESS_CODE"": ""D"",
-                ""POSTAL_ADDRESS_CODE_DESCRIPTION"": ""A record which is linked to PAF"",
-                ""BLPU_STATE_CODE"": ""2"",
-                ""BLPU_STATE_CODE_DESCRIPTION"": ""In use"",
-                ""TOPOGRAPHY_LAYER_TOID"": ""osgb1000009999999"",
-                ""LAST_UPDATE_DATE"": ""30/07/2017"",
-                ""ENTRY_DATE"": ""18/09/2007"",
-                ""BLPU_STATE_DATE"": ""01/04/2009"",
-                ""STREET_STATE_CODE"": ""2"",
-                ""STREET_STATE_CODE_DESCRIPTION"": ""Open"",
-                ""STREET_CLASSIFICATION_CODE"": ""8"",
-                ""STREET_CLASSIFICATION_CODE_DESCRIPTION"": ""All vehicles"",
-                ""LPI_LOGICAL_STATUS_CODE"": ""1"",
-                ""LPI_LOGICAL_STATUS_CODE_DESCRIPTION"": ""APPROVED"",
-                ""LANGUAGE"": ""EN"",
-                ""MATCH"": 1.0,
-                ""MATCH_DESCRIPTION"": ""EXACT""
-            }
-        }
-    ]
-}";
-    
+
     // First property postal address code = N
     // Second property logical status code = 0
     // Third property classification code = CO

--- a/HerPublicWebsite.UnitTests/BusinessLogic/ExternalServices/OsPlaces/OsPlacesLpiDtoTests.cs
+++ b/HerPublicWebsite.UnitTests/BusinessLogic/ExternalServices/OsPlaces/OsPlacesLpiDtoTests.cs
@@ -128,4 +128,39 @@ public class OsPlacesLpiDtoTests
         result.Uprn.Should().Be("123456789012");
         result.LocalCustodianCode.Should().Be("123");
     }
+    
+    [TestCase("C", "1", "RD06", true)] // Current residential postal address
+    [TestCase("C", "1", "CE01", true)] // Current educational postal address
+    [TestCase("C", "1", "X01", true)] // Current dual-use (residential and commercial) postal address
+    [TestCase("C", "1", "M01", true)] // Current military postal address
+    [TestCase("N", "1", "RD06", false)] // Current residential non-postal address
+    [TestCase("C", "0", "RD06", false)] // Non-current residential postal address
+    [TestCase("C", "1", "PP", false)] // Current non-residential/educational/etc postal address
+    public void IsCurrentResidential_WithVariousData_ReturnsAsExpected(
+        string postalAddressCode,
+        string lpiLogicalStatusCode,
+        string classificationCode,
+        bool expectedResult)
+    {
+        // Arrange
+        var underTest = new OsPlacesLpiDto
+        {
+            PostalAddressCode = postalAddressCode,
+            LpiLogicalStatusCode = lpiLogicalStatusCode,
+            ClassificationCode = classificationCode,
+            PaoText = "EXAMPLE HOUSE",
+            StreetDescription = "EXAMPLE ROAD",
+            TownName = "EXAMPLETON",
+            AdministrativeArea = "EXAMPLESHIRE",
+            PostcodeLocator = "AB1 2CD",
+            Uprn = "123456789012",
+            LocalCustodianCode = "123",
+        };
+        
+        // Act
+        var result = underTest.IsCurrentResidential();
+        
+        // Assert
+        result.Should().Be(expectedResult);
+    }
 }


### PR DESCRIPTION
Filter out address that aren't residential properties. We now use the same criteria as R2V

Specific problem case was buildings containing flats. but this should also remove any other address that isn't a residential property.