### PR TITLE
In production redirect to the gas boiler page as the first page

### DIFF
--- a/HerPublicWebsite/Controllers/QuestionnaireController.cs
+++ b/HerPublicWebsite/Controllers/QuestionnaireController.cs
@@ -48,7 +48,7 @@ public class QuestionnaireController : Controller
     [ExcludeFromSessionExpiry]
     public IActionResult Index()
     {
-        return RedirectToAction(nameof(StaticPagesController.Index), "StaticPages");
+        return RedirectToAction(nameof(GasBoiler_Get), "Questionnaire");
     }
 
     [HttpGet("boiler")]

--- a/HerPublicWebsite/Controllers/StaticPagesController.cs
+++ b/HerPublicWebsite/Controllers/StaticPagesController.cs
@@ -18,7 +18,7 @@ public class StaticPagesController : Controller
     {
         if (environment.IsProduction())
         {
-            return Redirect(Constants.SERVICE_URL);
+            return RedirectToAction(nameof(QuestionnaireController.GasBoiler_Get), "Questionnaire");
         }
 
         return View("Index");


### PR DESCRIPTION
This will make the site simpler access until the GDS page exists