### PR TITLE
BEISHER-826: Add digital assistance view and controller

### DIFF
--- a/HerPublicWebsite/Controllers/StaticPagesController.cs
+++ b/HerPublicWebsite/Controllers/StaticPagesController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Hosting;
+﻿using System.Threading.Tasks;
+using HerPublicWebsite.ExternalServices.GoogleAnalytics;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Hosting;
 
@@ -7,10 +10,12 @@ namespace HerPublicWebsite.Controllers;
 public class StaticPagesController : Controller
 {
     private readonly IWebHostEnvironment environment;
+    private readonly GoogleAnalyticsService googleAnalyticsService;
 
-    public StaticPagesController(IWebHostEnvironment environment)
+    public StaticPagesController(IWebHostEnvironment environment, GoogleAnalyticsService googleAnalyticsService)
     {
         this.environment = environment;
+        this.googleAnalyticsService = googleAnalyticsService;
     }
 
     [HttpGet("/")]
@@ -35,5 +40,12 @@ public class StaticPagesController : Controller
     public IActionResult SessionExpired()
     {
         return View("SessionExpired");
+    }
+    
+    [HttpGet("/digital-assistance")]
+    public async Task<IActionResult> DigitalAssistance()
+    {
+        await googleAnalyticsService.SendDigitalAssistanceEventAsync(Request);
+        return View("DigitalAssistance");
     }
 }

--- a/HerPublicWebsite/ExternalServices/GoogleAnalytics/GoogleAnalyticsService.cs
+++ b/HerPublicWebsite/ExternalServices/GoogleAnalytics/GoogleAnalyticsService.cs
@@ -19,6 +19,8 @@ public class GoogleAnalyticsService
     private const string EventNameBoilerQuestionViewed = "boiler_question_viewed";
     private const string EventNameQuestionnaireCompleted = "questionnaire_completed";
     private const string EventNameReferralGenerated = "referral_generated";
+    private const string EventNameDigitalAssistance = "digital_assistance";
+
     
     public GoogleAnalyticsService(
         IOptions<GoogleAnalyticsConfiguration> options,
@@ -70,6 +72,25 @@ public class GoogleAnalyticsService
                     Name = EventNameReferralGenerated
                 }
             }
+        });
+    }
+    
+    public async Task SendDigitalAssistanceEventAsync(HttpRequest request)
+    {
+        await SendEventAsync(new GaRequestBody
+        {
+            ClientId = GetClientId(request),
+            GaEvents = new List<GaEvent>
+            {
+                new()
+                {
+                    Name = EventNameDigitalAssistance,
+                    Parameters = new Dictionary<string, object>
+                    {
+                        {"digitalassistance", true}
+                    }
+                }
+            },
         });
     }
     

--- a/HerPublicWebsite/Views/StaticPages/DigitalAssistance.cshtml
+++ b/HerPublicWebsite/Views/StaticPages/DigitalAssistance.cshtml
@@ -1,0 +1,15 @@
+<h1 class="govuk-heading-l">
+    Welcome to the Home Upgrade Grant Digitial Assistance landing page
+</h1>
+
+<p class="govuk-body">Please ensure you have accepted all cookies for this website before continuing.</p>
+<p class="govuk-body">Once you have accepted cookies, click the button below to continue.</p>
+
+<a href="https://www.gov.uk/apply-home-upgrade-grant" role="button" draggable="false" class="govuk-button govuk-button--start"
+   data-module="govuk-button">
+    Continue to start page
+    <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19"
+         viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>
+    </svg>
+</a>


### PR DESCRIPTION
- Added a DigitalAssistance view and method in the StaticPagesController
- Added a new method in the GoogleAnalyticsService to send a digital assistance event, which sets a 'true' flag when a user lands on the digital assistance page
- Changes are not yet testable as we are waiting for GA credentials needed to access the GA site