### PR TITLE
BEISHER-NONE: Add tab title to the digital assistance page

### DIFF
--- a/HerPublicWebsite/Views/StaticPages/DigitalAssistance.cshtml
+++ b/HerPublicWebsite/Views/StaticPages/DigitalAssistance.cshtml
@@ -1,3 +1,7 @@
+@{
+    ViewBag.Title = "Digital Assistance Landing Page";
+}
+
 <h1 class="govuk-heading-l">
     Welcome to the Home Upgrade Grant Digital Assistance landing page
 </h1>


### PR DESCRIPTION
We have been told that the desired page title is `HUG2 | Digital Assistance Landing Page | GOV.UK`, however the way that the layout html is structured means that we inject a page title into a title template, so currently our page title would be `Digital Assistance Landing Page | Check if you are eligible for an energy grant for a home with no gas boiler | Gov.uk`.

We could ask if this is OK with the client; however, I think our title template is quite long so we might want to rework that too, e.g. 'Home Upgrade Grant | GOV.UK' . 

For some context, this is the dynamic HTML code snippet from _Layout.cshtml which generates page titles:

`<title>@(ViewBag.Title != null ? ViewBag.Title + " -" : "") @Constants.SERVICE_NAME - Gov.UK</title>`

@AyaPK 