### PR TITLE
PC-493 Be more lenient with antiforgery cookie to allow health-check to work

### DIFF
--- a/HerPublicWebsite/Controllers/HealthCheckController.cs
+++ b/HerPublicWebsite/Controllers/HealthCheckController.cs
@@ -5,6 +5,7 @@ namespace HerPublicWebsite.Controllers
     public class HealthCheckController : Controller
     {
         [HttpGet("/health-check")]
+        [IgnoreAntiforgeryToken]
         public IActionResult Index()
         {
             return View("Index");

--- a/HerPublicWebsite/Startup.cs
+++ b/HerPublicWebsite/Startup.cs
@@ -139,6 +139,7 @@ namespace HerPublicWebsite
         {
             services.Configure<CookieServiceConfiguration>(
                 configuration.GetSection(CookieServiceConfiguration.ConfigSection));
+            
             // Change the default antiforgery cookie name so it doesn't include Asp.Net for security reasons
             services.AddAntiforgery(options =>
             {
@@ -169,12 +170,12 @@ namespace HerPublicWebsite
             services.Configure<GovUkNotifyConfiguration>(
                 configuration.GetSection(GovUkNotifyConfiguration.ConfigSection));
         }
-        
+
         private void ConfigureS3Client(IServiceCollection services)
         {
             var s3Config = new S3Configuration();
             configuration.GetSection(S3Configuration.ConfigSection).Bind(s3Config);
-            
+
             if (webHostEnvironment.IsDevelopment())
             {
                 services.AddScoped(_ =>
@@ -194,7 +195,7 @@ namespace HerPublicWebsite
                 services.AddScoped(_ => new AmazonS3Client(RegionEndpoint.GetBySystemName(s3Config.Region)));
             }
         }
-        
+
         private void ConfigureS3FileWriter(IServiceCollection services)
         {
             services.Configure<S3Configuration>(
@@ -237,7 +238,7 @@ namespace HerPublicWebsite
                 // In production we terminate TLS at the load balancer and redirect there
                 app.UseHttpsRedirection();
             }
-            
+
             app.Use(async (context, next) =>
             {
                 if (context.Request.Path.StartsWithSegments("/robots.txt"))
@@ -274,7 +275,7 @@ namespace HerPublicWebsite
 
         private void ConfigureHttpBasicAuth(IApplicationBuilder app)
         {
-            if (!webHostEnvironment.IsDevelopment()&& !webHostEnvironment.IsProduction())
+            if (!webHostEnvironment.IsDevelopment() && !webHostEnvironment.IsProduction())
             {
                 // Add HTTP Basic Authentication in our non-local-development and non-production environments
                 // to make sure people don't accidentally stumble across the site


### PR DESCRIPTION
The 500s on internal health checks were coming from the internal check going over HTTP (i.e. no SSL), and our antiforgery cookie having `CookieSecurePolicy.Always` set on it. Was originally going to exclude health-check from antiforgery, but checked SEA (see [here](https://github.com/UKGovernmentBEIS/beis-simple-energy-advice-beta/blob/main/SeaPublicWebsite/Startup.cs#L120)) and saw that it just didn't set these properties on the cookie, so opted for that approach.