### PR TITLE
Revert "PC-853: Set Croydon's status to "Pending"."

### DIFF
--- a/HerPublicWebsite.BusinessLogic/Models/LocalAuthorityData.cs
+++ b/HerPublicWebsite.BusinessLogic/Models/LocalAuthorityData.cs
@@ -113,7 +113,7 @@ public class LocalAuthorityData
         { "1610", new LocalAuthorityDetails("Cotswold District Council", Hug2Status.Live, "https://www.cotswold.gov.uk/", IncomeBandOptions[IncomeThreshold._31000],"Stroud") },
         { "4610", new LocalAuthorityDetails("Coventry City Council", Hug2Status.Pending, "https://www.coventry.gov.uk/", IncomeBandOptions[IncomeThreshold._31000],"Midlands NetZero Hub") },
         { "3820", new LocalAuthorityDetails("Crawley Borough Council", Hug2Status.Live, "https://crawley.gov.uk/", IncomeBandOptions[IncomeThreshold._31000],"Portsmouth") },
-        { "5240", new LocalAuthorityDetails("London Borough of Croydon", Hug2Status.Pending, "http://www.croydon.gov.uk", IncomeBandOptions[IncomeThreshold._31000],"Greater London Authority") },
+        { "5240", new LocalAuthorityDetails("London Borough of Croydon", Hug2Status.Live, "http://www.croydon.gov.uk", IncomeBandOptions[IncomeThreshold._31000],"Greater London Authority") },
         { "940", new LocalAuthorityDetails("Cumberland Council", Hug2Status.NotTakingPart, "https://www.cumberland.gov.uk/", IncomeBandOptions[IncomeThreshold._31000],"Eden District Council") },
         { "1910", new LocalAuthorityDetails("Dacorum Borough Council", Hug2Status.Pending, "http://www.dacorum.gov.uk/", IncomeBandOptions[IncomeThreshold._31000],"Cambridgeshire & Peterborough Combined Authority") },
         { "1350", new LocalAuthorityDetails("Darlington Borough Council", Hug2Status.Pending, "https://www.darlington.gov.uk/", IncomeBandOptions[IncomeThreshold._31000],"Darlington Borough Council") },

--- a/HerPublicWebsite.UnitTests/BusinessLogic/Models/ExpectedLocalAuthorityData/LocalAuthorityStatuses.cs
+++ b/HerPublicWebsite.UnitTests/BusinessLogic/Models/ExpectedLocalAuthorityData/LocalAuthorityStatuses.cs
@@ -87,7 +87,7 @@ internal static class LocalAuthorityStatuses
             { "1610", Live },
             { "4610", Pending },
             { "3820", Live },
-            { "5240", Pending },
+            { "5240", Live },
             { "940", NotTakingPart },
             { "1910", Pending },
             { "1350", Pending },


### PR DESCRIPTION
Reverts UKGovernmentBEIS/desnz-home-energy-retrofit-beta#261

As discussed on [PC-853](https://beisdigital.atlassian.net/browse/PC-853), this change is no longer required.