### PR TITLE
PC-776: UAT bugfix: Incorrect Redirect from Not Participating

### DIFF
--- a/HerPublicWebsite/Views/Questionnaire/NotParticipating.cshtml
+++ b/HerPublicWebsite/Views/Questionnaire/NotParticipating.cshtml
@@ -46,7 +46,7 @@
         }
         else
         {
-            <form action="@Url.Action(nameof(QuestionnaireController.NotTakingPart_Post), "Questionnaire")" method="post" novalidate>
+            <form action="@Url.Action(nameof(QuestionnaireController.NotParticipating_Post), "Questionnaire")" method="post" novalidate>
                 @(Html.HiddenFor(m => m.EntryPoint))
                 @Html.AntiForgeryToken()
 


### PR DESCRIPTION
Fixed issue with incorrect redirect from email entry on "Not Participating" page to "Not Taking Part"