### PR TITLE
PC-696 Set up scheduled monthly email

### DIFF
--- a/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
+++ b/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
@@ -109,21 +109,20 @@ namespace HerPublicWebsite.BusinessLogic.ExternalServices.EmailSending
         }
         
         public void SendComplianceEmail(
-                MemoryStream recentReferralRequestOverviewFileData,
-                MemoryStream recentReferralRequestFollowUpFileData,
-                MemoryStream historicReferralRequestFollowUpFileData
-                )
-                {
-                    var recipientList = govUkNotifyConfig.ComplianceEmailRecipients;
-                    var template = govUkNotifyConfig.ComplianceReportTemplate;
-                    Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
-                    {
-                        { "File1Link", NotificationClient.PrepareUpload(recentReferralRequestOverviewFileData.ToArray(), true)},
-                        { "File2Link", NotificationClient.PrepareUpload(recentReferralRequestFollowUpFileData.ToArray(), true)},
-                        { "File3Link", NotificationClient.PrepareUpload(historicReferralRequestFollowUpFileData.ToArray(), true)},
-                    };
-                    SendEmailToRecipients(recipientList, template.Id, personalisation);
-                }
+            MemoryStream recentReferralRequestOverviewFileData,
+            MemoryStream recentReferralRequestFollowUpFileData,
+            MemoryStream historicReferralRequestFollowUpFileData)
+        {
+            var recipientList = govUkNotifyConfig.ComplianceEmailRecipients;
+            var template = govUkNotifyConfig.ComplianceReportTemplate;
+            var personalisation = new Dictionary<string, dynamic>
+            {
+                { template.File1Link, NotificationClient.PrepareUpload(recentReferralRequestOverviewFileData.ToArray(), true)},
+                { template.File2Link, NotificationClient.PrepareUpload(recentReferralRequestFollowUpFileData.ToArray(), true)},
+                { template.File3Link, NotificationClient.PrepareUpload(historicReferralRequestFollowUpFileData.ToArray(), true)},
+            };
+            SendEmailToRecipients(recipientList, template.Id, personalisation);
+        }
 
         public void SendPendingReferralReportEmail()
         {

--- a/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
+++ b/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
@@ -143,12 +143,12 @@ namespace HerPublicWebsite.BusinessLogic.ExternalServices.EmailSending
         public void SendPendingReferralReportEmail()
         {
             var recipientList = govUkNotifyConfig.PendingReferralEmailRecipients;
-            if (String.IsNullOrEmpty(recipientList))
+            if (string.IsNullOrEmpty(recipientList))
             {
                 return;
             }
             var template = govUkNotifyConfig.PendingReferralReportTemplate;
-            Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
+            var personalisation = new Dictionary<string, dynamic>
             {
                 { "Link", "https://www.gov.uk/apply-home-upgrade-grant" },
             };

--- a/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
+++ b/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
@@ -120,9 +120,9 @@ namespace HerPublicWebsite.BusinessLogic.ExternalServices.EmailSending
             var template = govUkNotifyConfig.ComplianceReportTemplate;
             var personalisation = new Dictionary<string, dynamic>
             {
-                { template.File1Link, NotificationClient.PrepareUpload(recentReferralRequestOverviewFileData.ToArray(), true)},
-                { template.File2Link, NotificationClient.PrepareUpload(recentReferralRequestFollowUpFileData.ToArray(), true)},
-                { template.File3Link, NotificationClient.PrepareUpload(historicReferralRequestFollowUpFileData.ToArray(), true)},
+                { "File1Link", NotificationClient.PrepareUpload(recentReferralRequestOverviewFileData.ToArray(), true)},
+                { "File2Link", NotificationClient.PrepareUpload(recentReferralRequestFollowUpFileData.ToArray(), true)},
+                { "File3Link", NotificationClient.PrepareUpload(historicReferralRequestFollowUpFileData.ToArray(), true)},
             };
             SendEmailToRecipients(recipientList, template.Id, personalisation);
         }

--- a/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
+++ b/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
@@ -137,7 +137,26 @@ namespace HerPublicWebsite.BusinessLogic.ExternalServices.EmailSending
                         SendEmail(emailModel);
                     }
                     
-                }    
+                }
+
+        public void SendPendingReferralReportEmail()
+        {
+            var recipientList = govUkNotifyConfig.PendingReferralEmailRecipients;
+            if (String.IsNullOrEmpty(recipientList))
+            {
+                return;
+            }
+            var template = govUkNotifyConfig.PendingReferralReportTemplate;
+            foreach (var emailAddress in recipientList.Split(","))
+            {
+                var emailModel = new GovUkNotifyEmailModel
+                {
+                    EmailAddress = emailAddress.Trim(),
+                    TemplateId = template.Id,
+                };
+                SendEmail(emailModel);
+            }
+        }
 
         private void SendReferenceCodeEmail
         (

--- a/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
+++ b/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
@@ -133,7 +133,7 @@ namespace HerPublicWebsite.BusinessLogic.ExternalServices.EmailSending
             var template = govUkNotifyConfig.PendingReferralReportTemplate;
             var personalisation = new Dictionary<string, dynamic>
             {
-                { template.Link, "https://www.gov.uk/apply-home-upgrade-grant" },
+                { template.LinkPlaceholder, "https://www.gov.uk/apply-home-upgrade-grant" },
             };
             SendEmailToRecipients(recipientList, template.Id, personalisation);
         }

--- a/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
+++ b/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
@@ -3,19 +3,20 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Notify.Client;
 using Notify.Exceptions;
+using Notify.Interfaces;
 
 namespace HerPublicWebsite.BusinessLogic.ExternalServices.EmailSending
 {
     public class GovUkNotifyApi : IEmailSender
     {
-        private readonly NotificationClient client;
+        private readonly INotificationClient client;
         private readonly GovUkNotifyConfiguration govUkNotifyConfig;
         private readonly ILogger<GovUkNotifyApi> logger;
         
-        public GovUkNotifyApi(IOptions<GovUkNotifyConfiguration> config, ILogger<GovUkNotifyApi> logger)
+        public GovUkNotifyApi(IOptions<GovUkNotifyConfiguration> config, ILogger<GovUkNotifyApi> logger, INotificationClient client)
         {
             govUkNotifyConfig = config.Value;
-            client = new NotificationClient(govUkNotifyConfig.ApiKey);
+            this.client = client;
             this.logger = logger;
         }
 

--- a/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
+++ b/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
@@ -115,11 +115,6 @@ namespace HerPublicWebsite.BusinessLogic.ExternalServices.EmailSending
                 )
                 {
                     var recipientList = govUkNotifyConfig.ComplianceEmailRecipients;
-                    if (String.IsNullOrEmpty(recipientList))
-                    {
-                        return;
-                    }
-                    
                     var template = govUkNotifyConfig.ComplianceReportTemplate;
                     Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
                     {
@@ -127,41 +122,18 @@ namespace HerPublicWebsite.BusinessLogic.ExternalServices.EmailSending
                         { "File2Link", NotificationClient.PrepareUpload(recentReferralRequestFollowUpFileData.ToArray(), true)},
                         { "File3Link", NotificationClient.PrepareUpload(historicReferralRequestFollowUpFileData.ToArray(), true)},
                     };
-                    foreach (var emailAddress in recipientList.Split(","))
-                    {
-                        var emailModel = new GovUkNotifyEmailModel
-                        {
-                            EmailAddress = emailAddress.Trim(),
-                            TemplateId = template.Id,
-                            Personalisation = personalisation
-                        };
-                        SendEmail(emailModel);
-                    }
-                    
+                    SendEmailToRecipients(recipientList, template.Id, personalisation);
                 }
 
         public void SendPendingReferralReportEmail()
         {
             var recipientList = govUkNotifyConfig.PendingReferralEmailRecipients;
-            if (string.IsNullOrEmpty(recipientList))
-            {
-                return;
-            }
             var template = govUkNotifyConfig.PendingReferralReportTemplate;
             var personalisation = new Dictionary<string, dynamic>
             {
-                { "Link", "https://www.gov.uk/apply-home-upgrade-grant" },
+                { template.Link, "https://www.gov.uk/apply-home-upgrade-grant" },
             };
-            foreach (var emailAddress in recipientList.Split(","))
-            {
-                var emailModel = new GovUkNotifyEmailModel
-                {
-                    EmailAddress = emailAddress.Trim(),
-                    TemplateId = template.Id,
-                    Personalisation = personalisation
-                };
-                SendEmail(emailModel);
-            }
+            SendEmailToRecipients(recipientList, template.Id, personalisation);
         }
 
         private void SendReferenceCodeEmail
@@ -204,6 +176,28 @@ namespace HerPublicWebsite.BusinessLogic.ExternalServices.EmailSending
                 Personalisation = personalisation
             };
             SendEmail(emailModel);
+        }
+
+        private void SendEmailToRecipients(
+            string recipientList, 
+            string templateId,
+            Dictionary<string, dynamic> personalisation)
+        {
+            if (string.IsNullOrEmpty(recipientList))
+            {
+                return;
+            }
+            var emailAddresses = recipientList.Split(",").Select(emailAddress => emailAddress.Trim());
+            foreach (var emailAddress in emailAddresses)
+            {
+                var emailModel = new GovUkNotifyEmailModel
+                {
+                    EmailAddress = emailAddress,
+                    TemplateId = templateId,
+                    Personalisation = personalisation
+                };
+                SendEmail(emailModel);
+            }
         }
     }
     

--- a/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
+++ b/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
@@ -13,10 +13,13 @@ namespace HerPublicWebsite.BusinessLogic.ExternalServices.EmailSending
         private readonly GovUkNotifyConfiguration govUkNotifyConfig;
         private readonly ILogger<GovUkNotifyApi> logger;
         
-        public GovUkNotifyApi(IOptions<GovUkNotifyConfiguration> config, ILogger<GovUkNotifyApi> logger, INotificationClient client)
+        public GovUkNotifyApi(
+            INotificationClient client,
+            IOptions<GovUkNotifyConfiguration> config,
+            ILogger<GovUkNotifyApi> logger)
         {
-            govUkNotifyConfig = config.Value;
             this.client = client;
+            govUkNotifyConfig = config.Value;
             this.logger = logger;
         }
 

--- a/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
+++ b/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
@@ -147,12 +147,17 @@ namespace HerPublicWebsite.BusinessLogic.ExternalServices.EmailSending
                 return;
             }
             var template = govUkNotifyConfig.PendingReferralReportTemplate;
+            Dictionary<String, dynamic> personalisation = new Dictionary<String, dynamic>
+            {
+                { "Link", "https://www.gov.uk/apply-home-upgrade-grant" },
+            };
             foreach (var emailAddress in recipientList.Split(","))
             {
                 var emailModel = new GovUkNotifyEmailModel
                 {
                     EmailAddress = emailAddress.Trim(),
                     TemplateId = template.Id,
+                    Personalisation = personalisation
                 };
                 SendEmail(emailModel);
             }

--- a/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyConfiguration.cs
+++ b/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyConfiguration.cs
@@ -6,6 +6,7 @@ public class GovUkNotifyConfiguration
         
     public string ApiKey { get; set; }
     public string ComplianceEmailRecipients { get; set; }
+    public string PendingReferralEmailRecipients { get; set; }
     public ReferenceCodeConfiguration ReferenceCodeForLiveLocalAuthorityTemplate { get; set; }
     public ReferenceCodeConfiguration ReferenceCodeForPendingLocalAuthorityTemplate { get; set; }
     public ReferralFollowUpConfiguration ReferralFollowUpTemplate { get; set; }

--- a/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyConfiguration.cs
+++ b/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyConfiguration.cs
@@ -45,4 +45,5 @@ public class ComplianceReportConfiguration
 public class PendingReferralReportConfiguration
 {
     public string Id { get; set; }
+    public string Link { get; set; }
 }

--- a/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyConfiguration.cs
+++ b/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyConfiguration.cs
@@ -11,6 +11,7 @@ public class GovUkNotifyConfiguration
     public ReferenceCodeConfiguration ReferenceCodeForPendingLocalAuthorityTemplate { get; set; }
     public ReferralFollowUpConfiguration ReferralFollowUpTemplate { get; set; }
     public ComplianceReportConfiguration ComplianceReportTemplate { get; set; }
+    public PendingReferralReportConfiguration PendingReferralReportTemplate { get; set; }
 }
 
 public class ReferenceCodeConfiguration
@@ -39,4 +40,9 @@ public class ComplianceReportConfiguration
     public string File1Link { get; set; }
     public string File2Link { get; set; }
     public string File3Link { get; set; }
+}
+
+public class PendingReferralReportConfiguration
+{
+    public string Id { get; set; }
 }

--- a/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyConfiguration.cs
+++ b/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyConfiguration.cs
@@ -45,5 +45,5 @@ public class ComplianceReportConfiguration
 public class PendingReferralReportConfiguration
 {
     public string Id { get; set; }
-    public string Link { get; set; }
+    public string LinkPlaceholder { get; set; }
 }

--- a/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/IEmailSender.cs
+++ b/HerPublicWebsite.BusinessLogic/ExternalServices/EmailSending/IEmailSender.cs
@@ -26,4 +26,6 @@ public interface IEmailSender
         MemoryStream recentReferralRequestFollowUpFileData,
         MemoryStream historicReferralRequestFollowUpFileData
     );
+    
+    public void SendPendingReferralReportEmail();
 }

--- a/HerPublicWebsite.BusinessLogic/Services/RegularJobs/PendingReferralNotificationService.cs
+++ b/HerPublicWebsite.BusinessLogic/Services/RegularJobs/PendingReferralNotificationService.cs
@@ -2,18 +2,11 @@
 
 namespace HerPublicWebsite.BusinessLogic.Services.RegularJobs;
 
-public interface IPendingReferralNotificationService
+public class PendingReferralNotificationService
 {
-    public void SendPendingReferralNotifications();
-}
-
-public class PendingReferralNotificationService : IPendingReferralNotificationService
-{
-    private IEmailSender emailSender;
+    private readonly IEmailSender emailSender;
     
-    public PendingReferralNotificationService(
-        IEmailSender emailSender
-    )
+    public PendingReferralNotificationService(IEmailSender emailSender)
     {
         this.emailSender = emailSender;
     }

--- a/HerPublicWebsite.BusinessLogic/Services/RegularJobs/PendingReferralNotificationService.cs
+++ b/HerPublicWebsite.BusinessLogic/Services/RegularJobs/PendingReferralNotificationService.cs
@@ -1,0 +1,25 @@
+﻿using HerPublicWebsite.BusinessLogic.ExternalServices.EmailSending;
+
+namespace HerPublicWebsite.BusinessLogic.Services.RegularJobs;
+
+public interface IPendingReferralNotificationService
+{
+    public void SendPendingReferralNotifications();
+}
+
+public class PendingReferralNotificationService : IPendingReferralNotificationService
+{
+    private IEmailSender emailSender;
+    
+    public PendingReferralNotificationService(
+        IEmailSender emailSender
+    )
+    {
+        this.emailSender = emailSender;
+    }
+    
+    public void SendPendingReferralNotifications()
+    {
+        this.emailSender.SendPendingReferralReportEmail();
+    }
+}

--- a/HerPublicWebsite.UnitTests/BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApiTests.cs
+++ b/HerPublicWebsite.UnitTests/BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApiTests.cs
@@ -88,4 +88,39 @@ public class GovUkNotifyApiTests
                 null, null));
         }
     }
+
+    [Test]
+    public void SendPendingReferralReportEmail_WhenCalled_DoesNotCallSendEmailIfEmailConfigIsEmpty()
+    {
+        // Arrange
+        const string recipient = "";
+        config.PendingReferralEmailRecipients = recipient;
+        
+        // Act
+        govUkNotifyApi.SendPendingReferralReportEmail();
+        
+        // Assert
+        mockNotificationClient.Verify(nc => nc.SendEmail(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<Dictionary<string, dynamic>>(),
+            null, null), Times.Never);
+    }
+
+    [Test]
+    public void SendPendingReferralReportEmail_WhenCalled_DoesNotCallSendEmailIfEmailConfigIsNull()
+    {
+        // Arrange
+        config.PendingReferralEmailRecipients = null;
+        
+        // Act
+        govUkNotifyApi.SendPendingReferralReportEmail();
+        
+        // Assert
+        mockNotificationClient.Verify(nc => nc.SendEmail(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<Dictionary<string, dynamic>>(),
+            null, null), Times.Never);
+    }
 }

--- a/HerPublicWebsite.UnitTests/BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApiTests.cs
+++ b/HerPublicWebsite.UnitTests/BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApiTests.cs
@@ -8,20 +8,20 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Notify.Interfaces;
 using NUnit.Framework;
+using Tests.Helpers;
 
 namespace Tests.BusinessLogic.ExternalServices.EmailSending;
 
 [TestFixture]
 public class GovUkNotifyApiTests
 {
-    private Mock<IOptions<GovUkNotifyConfiguration>> mockConfig;
+    private GovUkNotifyConfiguration config;
     private ILogger<GovUkNotifyApi> logger;
     private Mock<INotificationClient> mockNotificationClient;
 
     [SetUp]
     public void Setup()
     {
-        mockConfig = new Mock<IOptions<GovUkNotifyConfiguration>>();
         logger = new NullLogger<GovUkNotifyApi>();
         mockNotificationClient = new Mock<INotificationClient>();
     }
@@ -33,7 +33,7 @@ public class GovUkNotifyApiTests
         const string exampleRecipient = "email1@example.com";
         const string exampleId = "0";
         const string exampleLink = "https://www.gov.uk/apply-home-upgrade-grant";
-        var configValue = new GovUkNotifyConfiguration
+        config = new GovUkNotifyConfiguration
         {
             PendingReferralEmailRecipients = exampleRecipient,
             PendingReferralReportTemplate = new PendingReferralReportConfiguration
@@ -42,8 +42,7 @@ public class GovUkNotifyApiTests
                 LinkPlaceholder = exampleLink
             }
         };
-        mockConfig.Setup(config => config.Value).Returns(configValue);
-        var emailSender = new GovUkNotifyApi(mockNotificationClient.Object, mockConfig.Object, logger);
+        var emailSender = new GovUkNotifyApi(mockNotificationClient.Object, config.AsOptions(), logger);
         
         // Act
         emailSender.SendPendingReferralReportEmail();
@@ -54,7 +53,7 @@ public class GovUkNotifyApiTests
             exampleId,
             new Dictionary<string, object>
             {
-                { configValue.PendingReferralReportTemplate.LinkPlaceholder, exampleLink }
+                { config.PendingReferralReportTemplate.LinkPlaceholder, exampleLink }
             },
             null, null));
     }
@@ -66,7 +65,7 @@ public class GovUkNotifyApiTests
         string[] exampleRecipients = { "email1@example.com", "email2@example.com", "email3@example.com" };
         const string exampleId = "0";
         const string exampleLink = "https://www.gov.uk/apply-home-upgrade-grant";
-        var configValue = new GovUkNotifyConfiguration
+        config = new GovUkNotifyConfiguration
         {
             PendingReferralEmailRecipients = String.Join(",", exampleRecipients),
             PendingReferralReportTemplate = new PendingReferralReportConfiguration
@@ -75,8 +74,7 @@ public class GovUkNotifyApiTests
                 LinkPlaceholder = exampleLink
             }
         };
-        mockConfig.Setup(config => config.Value).Returns(configValue);
-        var emailSender = new GovUkNotifyApi(mockNotificationClient.Object, mockConfig.Object, logger);
+        var emailSender = new GovUkNotifyApi(mockNotificationClient.Object, config.AsOptions(), logger);
         
         // Act
         emailSender.SendPendingReferralReportEmail();
@@ -96,7 +94,7 @@ public class GovUkNotifyApiTests
                 exampleId,
                 new Dictionary<string, object>
                 {
-                    { configValue.PendingReferralReportTemplate.LinkPlaceholder, exampleLink }
+                    { config.PendingReferralReportTemplate.LinkPlaceholder, exampleLink }
                 },
                 null, null));
         }

--- a/HerPublicWebsite.UnitTests/BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApiTests.cs
+++ b/HerPublicWebsite.UnitTests/BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApiTests.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using HerPublicWebsite.BusinessLogic.ExternalServices.EmailSending;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Notify.Interfaces;
+using NUnit.Framework;
+
+namespace Tests.BusinessLogic.ExternalServices.EmailSending;
+
+[TestFixture]
+public class GovUkNotifyApiTests
+{
+    private Mock<IOptions<GovUkNotifyConfiguration>> mockConfig;
+    private ILogger<GovUkNotifyApi> logger;
+    private Mock<INotificationClient> mockNotificationClient;
+
+    [SetUp]
+    public void Setup()
+    {
+        mockConfig = new Mock<IOptions<GovUkNotifyConfiguration>>();
+        logger = new NullLogger<GovUkNotifyApi>();
+        mockNotificationClient = new Mock<INotificationClient>();
+    }
+
+    [Test]
+    public void SendPendingReferralReportEmail_WhenCalled_CallsSendEmailOnEmailInConfig()
+    {
+        // Arrange
+        const string exampleRecipient = "email1@example.com";
+        const string exampleId = "0";
+        const string exampleLink = "https://www.gov.uk/apply-home-upgrade-grant";
+        var configValue = new GovUkNotifyConfiguration
+        {
+            PendingReferralEmailRecipients = exampleRecipient,
+            PendingReferralReportTemplate = new PendingReferralReportConfiguration
+            {
+                Id = exampleId,
+                Link = exampleLink
+            }
+        };
+        mockConfig.Setup(config => config.Value).Returns(configValue);
+        var emailSender = new GovUkNotifyApi(mockConfig.Object, logger, mockNotificationClient.Object);
+        
+        // Act
+        emailSender.SendPendingReferralReportEmail();
+        
+        // Assert
+        mockNotificationClient.Verify(nc => nc.SendEmail(
+            exampleRecipient,
+            exampleId,
+            new Dictionary<string, object>
+            {
+                { "Link", exampleLink }
+            },
+            null, null));
+    }
+
+    [Test]
+    public void SendPendingReferralReportEmail_WhenCalled_CallsSendEmailOnAllEmailsInConfig()
+    {
+        // Arrange
+        string[] exampleRecipients = { "email1@example.com", "email2@example.com", "email3@example.com" };
+        const string exampleId = "0";
+        const string exampleLink = "https://www.gov.uk/apply-home-upgrade-grant";
+        var configValue = new GovUkNotifyConfiguration
+        {
+            PendingReferralEmailRecipients = String.Join(",", exampleRecipients),
+            PendingReferralReportTemplate = new PendingReferralReportConfiguration
+            {
+                Id = exampleId,
+                Link = exampleLink
+            }
+        };
+        mockConfig.Setup(config => config.Value).Returns(configValue);
+        var emailSender = new GovUkNotifyApi(mockConfig.Object, logger, mockNotificationClient.Object);
+        
+        // Act
+        emailSender.SendPendingReferralReportEmail();
+        
+        // Assert
+        mockNotificationClient.Verify(nc => nc.SendEmail(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<Dictionary<string, dynamic>>(),
+            null, null),
+            Times.Exactly(exampleRecipients.Length));
+        
+        foreach (var recipient in exampleRecipients)
+        {
+            mockNotificationClient.Verify(nc => nc.SendEmail(
+                recipient,
+                exampleId,
+                new Dictionary<string, object>
+                {
+                    { "Link", exampleLink }
+                },
+                null, null));
+        }
+    }
+}

--- a/HerPublicWebsite.UnitTests/BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApiTests.cs
+++ b/HerPublicWebsite.UnitTests/BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApiTests.cs
@@ -54,7 +54,7 @@ public class GovUkNotifyApiTests
             exampleId,
             new Dictionary<string, object>
             {
-                { "Link", exampleLink }
+                { configValue.PendingReferralReportTemplate.Link, exampleLink }
             },
             null, null));
     }
@@ -96,7 +96,7 @@ public class GovUkNotifyApiTests
                 exampleId,
                 new Dictionary<string, object>
                 {
-                    { "Link", exampleLink }
+                    { configValue.PendingReferralReportTemplate.Link, exampleLink }
                 },
                 null, null));
         }

--- a/HerPublicWebsite.UnitTests/BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApiTests.cs
+++ b/HerPublicWebsite.UnitTests/BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApiTests.cs
@@ -43,7 +43,7 @@ public class GovUkNotifyApiTests
             }
         };
         mockConfig.Setup(config => config.Value).Returns(configValue);
-        var emailSender = new GovUkNotifyApi(mockConfig.Object, logger, mockNotificationClient.Object);
+        var emailSender = new GovUkNotifyApi(mockNotificationClient.Object, mockConfig.Object, logger);
         
         // Act
         emailSender.SendPendingReferralReportEmail();
@@ -76,7 +76,7 @@ public class GovUkNotifyApiTests
             }
         };
         mockConfig.Setup(config => config.Value).Returns(configValue);
-        var emailSender = new GovUkNotifyApi(mockConfig.Object, logger, mockNotificationClient.Object);
+        var emailSender = new GovUkNotifyApi(mockNotificationClient.Object, mockConfig.Object, logger);
         
         // Act
         emailSender.SendPendingReferralReportEmail();

--- a/HerPublicWebsite.UnitTests/BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApiTests.cs
+++ b/HerPublicWebsite.UnitTests/BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApiTests.cs
@@ -39,7 +39,7 @@ public class GovUkNotifyApiTests
             PendingReferralReportTemplate = new PendingReferralReportConfiguration
             {
                 Id = exampleId,
-                Link = exampleLink
+                LinkPlaceholder = exampleLink
             }
         };
         mockConfig.Setup(config => config.Value).Returns(configValue);
@@ -54,7 +54,7 @@ public class GovUkNotifyApiTests
             exampleId,
             new Dictionary<string, object>
             {
-                { configValue.PendingReferralReportTemplate.Link, exampleLink }
+                { configValue.PendingReferralReportTemplate.LinkPlaceholder, exampleLink }
             },
             null, null));
     }
@@ -72,7 +72,7 @@ public class GovUkNotifyApiTests
             PendingReferralReportTemplate = new PendingReferralReportConfiguration
             {
                 Id = exampleId,
-                Link = exampleLink
+                LinkPlaceholder = exampleLink
             }
         };
         mockConfig.Setup(config => config.Value).Returns(configValue);
@@ -96,7 +96,7 @@ public class GovUkNotifyApiTests
                 exampleId,
                 new Dictionary<string, object>
                 {
-                    { configValue.PendingReferralReportTemplate.Link, exampleLink }
+                    { configValue.PendingReferralReportTemplate.LinkPlaceholder, exampleLink }
                 },
                 null, null));
         }

--- a/HerPublicWebsite.UnitTests/BusinessLogic/Services/PendingReferralNotificationServiceTests.cs
+++ b/HerPublicWebsite.UnitTests/BusinessLogic/Services/PendingReferralNotificationServiceTests.cs
@@ -21,8 +21,6 @@ public class PendingReferralNotificationServiceTests
     [Test]
     public void SendPendingReferralNotifications_WhenCalled_CallsSendPendingReferralReportEmail()
     {
-        // Arrange
-        
         // Act
         pendingReferralNotificationService.SendPendingReferralNotifications();
         

--- a/HerPublicWebsite.UnitTests/BusinessLogic/Services/PendingReferralNotificationServiceTests.cs
+++ b/HerPublicWebsite.UnitTests/BusinessLogic/Services/PendingReferralNotificationServiceTests.cs
@@ -1,0 +1,32 @@
+﻿using HerPublicWebsite.BusinessLogic.ExternalServices.EmailSending;
+using HerPublicWebsite.BusinessLogic.Services.RegularJobs;
+using Moq;
+using NUnit.Framework;
+
+namespace Tests.BusinessLogic.Services;
+
+[TestFixture]
+public class PendingReferralNotificationServiceTests
+{
+    private Mock<IEmailSender> mockEmailSender;
+    private PendingReferralNotificationService pendingReferralNotificationService;
+    
+    [SetUp]
+    public void Setup()
+    {
+        mockEmailSender = new Mock<IEmailSender>();
+        pendingReferralNotificationService = new PendingReferralNotificationService(mockEmailSender.Object);
+    }
+
+    [Test]
+    public void SendPendingReferralNotifications_WhenCalled_CallsSendPendingReferralReportEmail()
+    {
+        // Arrange
+        
+        // Act
+        pendingReferralNotificationService.SendPendingReferralNotifications();
+        
+        // Assert
+        mockEmailSender.Verify(es => es.SendPendingReferralReportEmail());
+    }
+}

--- a/HerPublicWebsite.UnitTests/Helpers/OptionsHelper.cs
+++ b/HerPublicWebsite.UnitTests/Helpers/OptionsHelper.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Extensions.Options;
+
+namespace Tests.Helpers;
+
+public static class OptionsHelper
+{
+    public static IOptions<T> AsOptions<T>(this T value) where T : class
+    {
+        return new TestOptions<T>(value);
+    }
+
+    private class TestOptions<T> : IOptions<T> where T : class
+    {
+        public TestOptions(T value)
+        {
+            Value = value;
+        }
+
+        public T Value { get; }
+    }
+}

--- a/HerPublicWebsite/Program.cs
+++ b/HerPublicWebsite/Program.cs
@@ -61,6 +61,14 @@ namespace HerPublicWebsite
                     "Send policy team update email",
                     rjs => rjs.SendPolicyTeamUpdate(),
                     "0 7 * * 1");
+            
+            app
+                .Services
+                .GetService<IRecurringJobManager>()
+                .AddOrUpdate<PendingReferralNotificationService>(
+                    "Send monthly pending referral report",
+                    rjs => rjs.SendPendingReferralNotifications(),
+                    "0 0 1 * *");
 
             app.Run();
         }

--- a/HerPublicWebsite/Startup.cs
+++ b/HerPublicWebsite/Startup.cs
@@ -33,6 +33,9 @@ using HerPublicWebsite.BusinessLogic.ExternalServices.OsPlaces;
 using HerPublicWebsite.BusinessLogic.Services.CsvFileCreator;
 using Microsoft.AspNetCore.Http;
 using HerPublicWebsite.BusinessLogic.Services.ReferralFollowUps;
+using Microsoft.Extensions.Options;
+using Notify.Client;
+using Notify.Interfaces;
 using GlobalConfiguration = HerPublicWebsite.BusinessLogic.GlobalConfiguration;
 
 namespace HerPublicWebsite
@@ -175,6 +178,11 @@ namespace HerPublicWebsite
             services.AddScoped<IEmailSender, GovUkNotifyApi>();
             services.Configure<GovUkNotifyConfiguration>(
                 configuration.GetSection(GovUkNotifyConfiguration.ConfigSection));
+            services.AddScoped<INotificationClient, NotificationClient>(serviceProvider =>
+            {
+                var govUkNotifyConfiguration = serviceProvider.GetService<IOptions<GovUkNotifyConfiguration>>();
+                return new NotificationClient(govUkNotifyConfiguration.Value.ApiKey);
+            });
         }
 
         private void ConfigureS3Client(IServiceCollection services)

--- a/HerPublicWebsite/appsettings.json
+++ b/HerPublicWebsite/appsettings.json
@@ -50,6 +50,10 @@
           "File1Link": "file 1 link",
           "File2Link": "file 2 link",
           "File3Link": "file 3 link"
+        },
+
+        "PendingReferralReportTemplate": {
+            "Id": "f844d3f6-0dc8-4fab-b3a2-8a65476cc5c7"
         }
     },
 

--- a/HerPublicWebsite/appsettings.json
+++ b/HerPublicWebsite/appsettings.json
@@ -54,7 +54,7 @@
 
         "PendingReferralReportTemplate": {
             "Id": "f844d3f6-0dc8-4fab-b3a2-8a65476cc5c7",
-            "Link": "link"
+            "LinkPlaceholder": "link"
         }
     },
 

--- a/HerPublicWebsite/appsettings.json
+++ b/HerPublicWebsite/appsettings.json
@@ -53,7 +53,8 @@
         },
 
         "PendingReferralReportTemplate": {
-            "Id": "f844d3f6-0dc8-4fab-b3a2-8a65476cc5c7"
+            "Id": "f844d3f6-0dc8-4fab-b3a2-8a65476cc5c7",
+            "Link": "link"
         }
     },
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Secrets must be configured in the ECS tasks, corresponding to the variables in `
 - `GoogleAnalytics__ApiKey`
 - `GovUkNotify__ApiKey`
 - `GovUkNotify__ComplianceEmailRecipients`
+- `GovUkNotify__PendingReferralEmailRecipients`
 - `OsPlaces__Key`
 
 To prevent public access to DEV and UAT environments, we should also override the basic auth credentials:


### PR DESCRIPTION
closes [PC-696](https://beisdigital.atlassian.net/browse/PC-696)

adds a monthly (on the 1st of the month) cronjob to send out a pending referral report email

the ticket did not explicitly specify what class of email this is, so speaking with Glenn we've agreed to call it a "pending referral report"

the template on GOV.UK notify is "Pending Referral Report"

the ticket didn't specifically mention also exactly whom is on the mailing list for these emails; for now I made a new config value `PendingReferralEmailRecipients` where a list can be specified, as I'm not sure if `ComplianceEmailRecipients` is practically the correct list

tests are included for the two service interactions