### PR TITLE
PC-883: Fix handling of old custodian codes in historical referrals

### DIFF
--- a/HerPublicWebsite.BusinessLogic/Services/RegularJobs/PendingReferralFilterService.cs
+++ b/HerPublicWebsite.BusinessLogic/Services/RegularJobs/PendingReferralFilterService.cs
@@ -1,4 +1,5 @@
-﻿using HerPublicWebsite.BusinessLogic.Models;
+﻿using HerPublicWebsite.BusinessLogic.ExternalServices.OsPlaces;
+using HerPublicWebsite.BusinessLogic.Models;
 
 namespace HerPublicWebsite.BusinessLogic.Services.RegularJobs;
 
@@ -25,7 +26,8 @@ public class PendingReferralFilterService : IPendingReferralFilterService
     
     private static bool ShouldIncludeInReport(ReferralRequest referral, DateTime startDate)
     {
-        var localAuthority = LocalAuthorityData.LocalAuthorityDetailsByCustodianCode[referral.CustodianCode];
+        var custodianCode = LaMapping.GetCurrentCustodianCode(referral.CustodianCode);
+        var localAuthority = LocalAuthorityData.LocalAuthorityDetailsByCustodianCode[custodianCode];
         var localAuthorityIsPending = localAuthority.Status == LocalAuthorityData.Hug2Status.Pending;
 
         // Also include referrals to local authorities that have gone from Pending to another status in the last month.


### PR DESCRIPTION
Some old referral requests use custodian codes which have now been mapped somewhere else and so don't appear in the list of LAs.

Since this new email selects for all referral requests ever, it is picking up some of those historic custodian codes. We need to map those to new values.