### PR TITLE
PC-995: Add caveat to SLA compliance email that users are sent

### DIFF
--- a/HerPublicWebsite/Views/ReferralRequestFollowUp/ResponsePage.cshtml
+++ b/HerPublicWebsite/Views/ReferralRequestFollowUp/ResponsePage.cshtml
@@ -15,6 +15,7 @@
         <div class="govuk-body">
             <p>Thank you for taking part in the HUG 2 Eligibility Checker on @Model.RequestDate.ToShortDateString().</p>
             <p>We are writing to check whether you have been contacted by your local authority (or their official contractor) in the last 10 working days.</p>
+            <p>Please do not submit a response to this question if at the time of submitting a referral you were told that your Local Authority is receiving applications but is not ready to process them yet. You will receive monthly updates from the Department of Energy Security and Net Zero about the status of your referral.</p>
             <p>Please indicate in the boxes below whether you have been contacted:</p>
         </div>
         <form action="@Url.Action(nameof(ReferralRequestFollowUpController.RespondPage_Post), "ReferralRequestFollowUp")" method="post" novalidate>


### PR DESCRIPTION
Updated copy test on ResponsePage.cshtml to let users know not to answer if the question is not applicable to them

![image](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-beta/assets/152421975/3bc9f1e7-a383-4b22-b902-9f76ac8d4abd)

Updated the GovNotify template email to include the caveat copy text.

![image](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-beta/assets/152421975/be9fe1d4-bdb5-4053-8d64-abb34c1e2428)
