### PR TITLE
PC-NONE: Add comments to clarify expected test behaviour

### DIFF
--- a/HerPublicWebsite.UnitTests/Website/Services/Cookies/CookieServiceTests.cs
+++ b/HerPublicWebsite.UnitTests/Website/Services/Cookies/CookieServiceTests.cs
@@ -154,7 +154,7 @@ public class CookieServiceTests
         // Assert
         bannerState.Should().Be(BannerState.Hide);
     }
-    
+
     [TestCaseSource(nameof(CookieServiceTestCases))]
     public void ShowsBannerIfSettingsAreOutdatedOrMissing(CookieServiceTestCase testCase)
     {
@@ -164,17 +164,17 @@ public class CookieServiceTests
         var request = context.Request;
         var response = context.Response;
         request.Headers.Cookie = $"{Key}={ConvertObjectToHttpHeaderSrting(value)}";
-        
-        // Precondition
+
+        // Precondition: the only cases we are testing are 'Missing cookie' and 'Outdated version'
         Assume.That(!CookieService.CookieSettingsAreUpToDate(request));
 
         // Act
         var bannerState = CookieService.GetAndUpdateBannerState(request, response);
-        
+
         // Assert
         bannerState.Should().Be(BannerState.ShowBanner);
     }
-    
+
     [TestCaseSource(nameof(CookieServiceTestCases))]
     public void HidesBannerIfCookiesWereSetAndConfirmationWasShown(CookieServiceTestCase testCase)
     {
@@ -184,18 +184,19 @@ public class CookieServiceTests
         var request = context.Request;
         var response = context.Response;
         request.Headers.Cookie = $"{Key}={ConvertObjectToHttpHeaderSrting(value)}";
-        
-        // Precondition
+
+        // Precondition: the only cases we are testing are 'Accepted latest cookies' and 'Rejected analytics and
+        // confirmation shown'
         Assume.That(CookieService.CookieSettingsAreUpToDate(request));
         Assume.That(value.ConfirmationShown);
 
         // Act
         var bannerState = CookieService.GetAndUpdateBannerState(request, response);
-        
+
         // Assert
         bannerState.Should().Be(BannerState.Hide);
     }
-    
+
     [TestCaseSource(nameof(CookieServiceTestCases))]
     public void ShowsConfirmationBannerAndUpdatesRequestCookieIfItWasNotShownAlready(CookieServiceTestCase testCase)
     {
@@ -205,14 +206,14 @@ public class CookieServiceTests
         var request = context.Request;
         var response = context.Response;
         request.Headers.Cookie = $"{Key}={ConvertObjectToHttpHeaderSrting(value)}";
-        
-        // Precondition
+
+        // Precondition: the only case we are testing is 'Rejected analytics and confirmation not shown'
         Assume.That(CookieService.CookieSettingsAreUpToDate(request));
         Assume.That(!value.ConfirmationShown);
 
         // Act
         var bannerState = CookieService.GetAndUpdateBannerState(request, response);
-        
+
         // Assert
         var expectedBannerState = value.GoogleAnalytics ? BannerState.ShowAccepted : BannerState.ShowRejected;
         bannerState.Should().Be(expectedBannerState);


### PR DESCRIPTION
# Description

We deliberately don't cover all test cases - they're split across three tests. Hopefully this will save someone a little time in rediscovering this in future!

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [ ] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [ ] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
- [ ] If I have made any changes to the Local Authority or Consortium data, I have made sure these changes have been reflected in [the HUG2 Portal repository](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-portal-beta)

# Screenshots

n/a