### PR TITLE
PC-1235 gas boiler wording change

### DIFF
--- a/HerPublicWebsite.BusinessLogic/Models/Enums/HasGasBoiler.cs
+++ b/HerPublicWebsite.BusinessLogic/Models/Enums/HasGasBoiler.cs
@@ -7,8 +7,8 @@ namespace HerPublicWebsite.BusinessLogic.Models.Enums;
 // invalid
 public enum HasGasBoiler
 {
-    [GovUkRadioCheckboxLabelText(Text = "No, I do not have a gas boiler")]
+    [GovUkRadioCheckboxLabelText(Text = "No, I do not have a mains gas boiler")]
     No = 0,
-    [GovUkRadioCheckboxLabelText(Text = "Yes, I have a gas boiler")]
+    [GovUkRadioCheckboxLabelText(Text = "Yes, I have a mains gas boiler")]
     Yes = 1,
 }

--- a/HerPublicWebsite/Constants.cs
+++ b/HerPublicWebsite/Constants.cs
@@ -3,6 +3,6 @@
 public static class Constants
 {
     public const string FEEDBACK_URL_DEFAULT = "https://forms.office.com/e/tsn29X5m91";
-    public const string SERVICE_NAME = "Check if you are eligible for an energy grant for a home with no gas boiler";
+    public const string SERVICE_NAME = "Check if you are eligible for an energy grant for a home with no mains gas boiler";
     public const string SERVICE_URL = "https://www.gov.uk/apply-home-upgrade-grant";
 }

--- a/HerPublicWebsite/Models/Questionnaire/GasBoilerViewModel.cs
+++ b/HerPublicWebsite/Models/Questionnaire/GasBoilerViewModel.cs
@@ -5,7 +5,7 @@ namespace HerPublicWebsite.Models.Questionnaire
 {
     public class GasBoilerViewModel : QuestionFlowViewModel
     {
-        [GovUkValidateRequired(ErrorMessageIfMissing = "Select yes if you have a gas boiler, or no if you do not have a gas boiler")]
+        [GovUkValidateRequired(ErrorMessageIfMissing = "Select yes if you have a mains gas boiler, or no if you do not have a mains gas boiler")]
         public HasGasBoiler? HasGasBoiler { get; set; }
     }
 }

--- a/HerPublicWebsite/Views/Questionnaire/CheckAnswers.cshtml
+++ b/HerPublicWebsite/Views/Questionnaire/CheckAnswers.cshtml
@@ -47,7 +47,7 @@
                            {
                                Key = new SummaryListRowKey
                                {
-                                   Text = "Do you have a gas boiler?"
+                                   Text = "Do you have a mains gas boiler?"
                                },
                                Value = new SummaryListRowValue
                                {

--- a/HerPublicWebsite/Views/Questionnaire/DirectToEco.cshtml
+++ b/HerPublicWebsite/Views/Questionnaire/DirectToEco.cshtml
@@ -3,7 +3,7 @@
 
 @model HerPublicWebsite.Models.Questionnaire.DirectToEcoViewModel
 @{
-    ViewBag.Title = "This service is for homes with no gas boiler";
+    ViewBag.Title = "This service is for homes with no mains gas boiler";
 }
 
 @section BeforeMain {
@@ -19,7 +19,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <h1 class="govuk-heading-l">This service is for homes with no gas boiler</h1>
+        <h1 class="govuk-heading-l">This service is for homes with no mains gas boiler</h1>
 
         <h2 class="govuk-heading-m">You might be able to get help from your energy supplier</h2>
 

--- a/HerPublicWebsite/Views/Questionnaire/GasBoiler.cshtml
+++ b/HerPublicWebsite/Views/Questionnaire/GasBoiler.cshtml
@@ -32,7 +32,7 @@
                        {
                            Legend = new LegendViewModel
                            {
-                               Text = "Do you have a gas boiler?",
+                               Text = "Do you have a mains gas boiler?",
                                Classes = "govuk-fieldset__legend--l",
                                IsPageHeading = true
                            }
@@ -40,7 +40,7 @@
                        new HintViewModel
                        {
                            Html = @<text>
-                                      <p class="govuk-body">To be eligible for the Home Upgrade Grant, you cannot use a gas boiler to heat the property.</p>
+                                      <p class="govuk-body">To be eligible for the Home Upgrade Grant, you cannot use a mains gas boiler to heat the property.</p>
                                       <p class="govuk-body">If you have two heating systems but use your gas boiler more than the other, choose ‘Yes, I have a gas boiler’.</p>
                                </text>
                                

--- a/HerPublicWebsite/Views/Questionnaire/GasBoiler.cshtml
+++ b/HerPublicWebsite/Views/Questionnaire/GasBoiler.cshtml
@@ -41,7 +41,7 @@
                        {
                            Html = @<text>
                                       <p class="govuk-body">To be eligible for the Home Upgrade Grant, you cannot use a mains gas boiler to heat the property.</p>
-                                      <p class="govuk-body">If you have two heating systems but use your gas boiler more than the other, choose ‘Yes, I have a gas boiler’.</p>
+                                      <p class="govuk-body">If you have two heating systems but use your mains gas boiler more than the other, choose ‘Yes, I have a mains gas boiler’.</p>
                                </text>
                                
                        },


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1235)


# Description

Changed wording to include "mains" before gas boiler

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVK6dT96k=/)
- [x] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
- [x] If I have made any changes to the Local Authority or Consortium data, I have made sure these changes have been reflected in [the HUG2 Portal repository](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-portal-beta)
- [x] If I have made any changes to the ReferralRequest model, I have made sure the data in FakeReferralGenerator.cs is still accurate

# Screenshots

![{64BCD4C4-31E2-4215-B0EE-50B45CB57356}](https://github.com/user-attachments/assets/e7edc26a-07ad-468c-a23f-ebc891ce509a)
![{909058E9-1FFE-4837-9BBB-A9F5A0E9F407}](https://github.com/user-attachments/assets/64f3a57b-8400-405a-a9a1-d9335a1c7213)
![{700C6443-BC7E-4569-BB4A-55E0D3CA2FD0}](https://github.com/user-attachments/assets/1069676b-42c1-4817-ad1f-02be59f31eed)
![{947E8AC9-8CFB-4C0C-8841-156D0312F3E3}](https://github.com/user-attachments/assets/245b9771-3a61-48f6-ad6c-b185814ecd93)

