### PR TITLE
PC-1352: Offboarding of LAs

### DIFF
--- a/HerPublicWebsite.BusinessLogic/Models/LocalAuthorityData.cs
+++ b/HerPublicWebsite.BusinessLogic/Models/LocalAuthorityData.cs
@@ -324,7 +324,7 @@ public class LocalAuthorityData
         { "9078", new LocalAuthorityDetails("Stirling Council", Hug2Status.NotTakingPart, "https://stirling.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
         { "4235", new LocalAuthorityDetails("Stockport Metropolitan Borough Council", Hug2Status.NotTakingPart, "https://www.stockport.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
         { "738", new LocalAuthorityDetails("Stockton-on-Tees Borough Council", Hug2Status.Pending, "https://www.stockton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Darlington Borough Council") },
-        { "3720", new LocalAuthorityDetails("Stratford-on-Avon District Council", Hug2Status.Live, "https://www.stratford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Midlands Net Zero Hub") },
+        { "3720", new LocalAuthorityDetails("Stratford-on-Avon District Council", Hug2Status.NoLongerParticipating, "https://www.stratford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Midlands Net Zero Hub") },
         { "1625", new LocalAuthorityDetails("Stroud District Council", Hug2Status.Live, "http://www.stroud.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council") },
         { "4525", new LocalAuthorityDetails("Sunderland City Council", Hug2Status.NotTakingPart, "https://www.sunderland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
         { "3640", new LocalAuthorityDetails("Surrey Heath Borough Council", Hug2Status.Live, "https://www.surreyheath.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },

--- a/HerPublicWebsite.UnitTests/BusinessLogic/Models/ExpectedLocalAuthorityData/LocalAuthorityStatuses.cs
+++ b/HerPublicWebsite.UnitTests/BusinessLogic/Models/ExpectedLocalAuthorityData/LocalAuthorityStatuses.cs
@@ -296,7 +296,7 @@ internal static class LocalAuthorityStatuses
             { "9078", NotTakingPart },
             { "4235", NotTakingPart },
             { "738", Pending },
-            { "3720", Live },
+            { "3720", NoLongerParticipating },
             { "1625", Live },
             { "4525", NotTakingPart },
             { "3640", Live },


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1352)

# Description

offboards stratford upon avon into our new NoLongerParticipating status

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVK4A7AsM=/)
- [x] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
- [x] If I have made any changes to the Local Authority or Consortium data, I have made sure these changes have been reflected in [the HUG2 Portal repository](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-portal-beta)
- [x] If I have made any changes to the ReferralRequest model, I have made sure the data in FakeReferralGenerator.cs is still accurate