### PR TITLE
PC-1159: Unclear contact details flow on LA Not Taking Part page

### DIFF
--- a/HerPublicWebsite/Views/Questionnaire/NoLongerParticipating.cshtml
+++ b/HerPublicWebsite/Views/Questionnaire/NoLongerParticipating.cshtml
@@ -1,8 +1,8 @@
 ﻿@using GovUkDesignSystem
 @using GovUkDesignSystem.GovUkDesignSystemComponents
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @using HerPublicWebsite.Controllers
 @using HerPublicWebsite.Models.Enums
+@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model HerPublicWebsite.Models.Questionnaire.NoLongerParticipatingViewModel
 
 @{

--- a/HerPublicWebsite/Views/Questionnaire/NoLongerParticipating.cshtml
+++ b/HerPublicWebsite/Views/Questionnaire/NoLongerParticipating.cshtml
@@ -39,7 +39,7 @@
                 {
                     Type = "success",
                     TitleText = "Success",
-                    Text = "Your contact details have been submitted.",
+                    Text = Model.CanContactByEmailAboutFutureSchemes is YesOrNo.Yes ? "Your contact details have been submitted." : "Your contact details have not been submitted.",
                     Role = "alert"
                 }
             )

--- a/HerPublicWebsite/Views/Questionnaire/NotParticipating.cshtml
+++ b/HerPublicWebsite/Views/Questionnaire/NotParticipating.cshtml
@@ -1,8 +1,8 @@
 ﻿@using GovUkDesignSystem
 @using GovUkDesignSystem.GovUkDesignSystemComponents
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @using HerPublicWebsite.Controllers
 @using HerPublicWebsite.Models.Enums
+@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model HerPublicWebsite.Models.Questionnaire.NotParticipatingViewModel
 
 @{

--- a/HerPublicWebsite/Views/Questionnaire/NotParticipating.cshtml
+++ b/HerPublicWebsite/Views/Questionnaire/NotParticipating.cshtml
@@ -39,7 +39,7 @@
                 {
                     Type = "success",
                     TitleText = "Success",
-                    Text = "Your contact details have been submitted.",
+                    Text = Model.CanContactByEmailAboutFutureSchemes is YesOrNo.Yes ? "Your contact details have been submitted." : "Your contact details have not been submitted.",
                     Role = "alert"
                 }
             )

--- a/HerPublicWebsite/Views/Questionnaire/NotTakingPart.cshtml
+++ b/HerPublicWebsite/Views/Questionnaire/NotTakingPart.cshtml
@@ -39,14 +39,14 @@
         @if (Model.Submitted)
         {
             @await Html.GovUkNotificationBanner(
-                       new NotificationBannerViewModel
-                       {
-                           Type = "success",
-                           TitleText = "Success",
-                           Text = "Your contact details have been submitted.",
-                           Role = "alert"
-                       }
-                       )
+                new NotificationBannerViewModel
+                {
+                    Type = "success",
+                    TitleText = "Success",
+                    Text = Model.CanContactByEmailAboutFutureSchemes is YesOrNo.Yes ? "Your contact details have been submitted." : "Your contact details have not been submitted.",
+                    Role = "alert"
+                }
+            )
         }
         else
         {

--- a/HerPublicWebsite/Views/Questionnaire/NotTakingPart.cshtml
+++ b/HerPublicWebsite/Views/Questionnaire/NotTakingPart.cshtml
@@ -1,10 +1,8 @@
 ﻿@using GovUkDesignSystem
 @using GovUkDesignSystem.GovUkDesignSystemComponents
-@using HerPublicWebsite.BusinessLogic.Models.Enums
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @using HerPublicWebsite.Controllers
 @using HerPublicWebsite.Models.Enums
-
+@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model HerPublicWebsite.Models.Questionnaire.NotTakingPartViewModel
 
 @{
@@ -16,26 +14,26 @@
         @await Html.GovUkBackLink(new BackLinkViewModel
         {
             Text = "Back",
-            Href = Model.BackLink,
+            Href = Model.BackLink
         })
     </nav>
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        
+
         <h1 class="govuk-heading-l">Your local authority is not taking part in the Home Upgrade Grant</h1>
-        
+
         <h2 class="govuk-heading-m">What to do next</h2>
 
         <p class="govuk-body">
-            Based on the information you provided, it looks like your local authority, <strong class="govuk-!-font-weight-bold">@Model.LocalAuthorityName</strong>, is not taking part in the Home Upgrade Grant. 
+            Based on the information you provided, it looks like your local authority, <strong class="govuk-!-font-weight-bold">@Model.LocalAuthorityName</strong>, is not taking part in the Home Upgrade Grant.
         </p>
-        
+
         <p class="govuk-body">
             If your local authority does not seem right, <a class="govuk-link" href="https://www.gov.uk/find-local-council">find your correct local authority</a> and contact them directly.
         </p>
-        
+
         @if (Model.Submitted)
         {
             @await Html.GovUkNotificationBanner(
@@ -55,59 +53,62 @@
                 @Html.AntiForgeryToken()
 
                 @await Html.GovUkRadiosFor(
-                           m => m.CanContactByEmailAboutFutureSchemes,
-                           fieldsetOptions: new FieldsetViewModel
-                           {
-                               Legend = new LegendViewModel
-                               {
-                                   Html = @<text>
-                                              <h2 class="govuk-fieldset__legend--m">Can we email you about future energy grants?</h2>
-                                              <p class="govuk-body">We will only email you when new grants for homes become available.</p>
-                                           </text>
-                               },
-                           },
-                           conditionalOptions: new Dictionary<YesOrNo, Conditional>
-                           {
-                               {
-                                   YesOrNo.Yes,
-                                   new Conditional
-                                   {
-                                       Html = (@<text>
-                                                   @await Html.GovUkTextInputFor(
-                                                              m => m.EmailAddress,
-                                                              labelOptions: new LabelViewModel
-                                                              {
-                                                                  Text = "Email address",
-                                                              },
-                                                              classes: "govuk-input govuk-input--width-20",
-                                                              autocomplete: "email")
-                                                </text>)
-                                   }
-                               }
-                           })
+                    m => m.CanContactByEmailAboutFutureSchemes,
+                    fieldsetOptions: new FieldsetViewModel
+                    {
+                        Legend = new LegendViewModel
+                        {
+                            Html = @<text>
+                                        <h2 class="govuk-fieldset__legend--m">Can we email you about future energy grants?</h2>
+                                        <p class="govuk-body">We will only email you when new grants for homes become available.</p>
+                                    </text>
+                        }
+                    },
+                    conditionalOptions: new Dictionary<YesOrNo, Conditional>
+                    {
+                        {
+                            YesOrNo.Yes,
+                            new Conditional
+                            {
+                                Html = (@<text>
+                                             @await Html.GovUkTextInputFor(
+                                                 m => m.EmailAddress,
+                                                 new LabelViewModel
+                                                 {
+                                                     Text = "Email address"
+                                                 },
+                                                 classes: "govuk-input govuk-input--width-20",
+                                                 autocomplete: "email")
+                                         </text>)
+                            }
+                        }
+                    })
                 <div class="govuk-button-group">
                     @(await Html.GovUkButton(new ButtonViewModel
                     {
-                        Text = "Submit",
+                        Text = "Submit"
                     }))
                 </div>
             </form>
         }
-        
+
         <h2 class="govuk-heading-m">You might be able to get help from your energy supplier</h2>
         <p class="govuk-body">
             You might be able to get help for energy-saving improvements to your home if you either:
         </p>
         <ul class="govuk-list govuk-list--bullet">
             <li>
-                claim certain benefits and live in private housing (for example you own your home or rent from a private landlord) 
+                claim certain benefits and live in private housing (for example you own your home or rent from a private landlord)
             </li>
             <li>
                 live in social housing
             </li>
         </ul>
         <p class="govuk-body">
-            Check if you are eligible for the <a class="govuk-link" href="https://www.gov.uk/energy-company-obligation">
-            Energy Company Obligation</a> scheme.</p>
+            Check if you are eligible for the
+            <a class="govuk-link" href="https://www.gov.uk/energy-company-obligation">
+                Energy Company Obligation
+            </a> scheme.
+        </p>
     </div>
 </div>


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1159)

# Description

adds a ternary to the Not Participating, No Longer Participating & Not Taking Part pages to show a different message if 'no' is selected

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [ ] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVK4A7AsM=/)
- [x] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
- [x] If I have made any changes to the Local Authority or Consortium data, I have made sure these changes have been reflected in [the HUG2 Portal repository](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-portal-beta)
- [x] If I have made any changes to the ReferralRequest model, I have made sure the data in FakeReferralGenerator.cs is still accurate

# Screenshots

not taking part
![image](https://github.com/user-attachments/assets/53676ed9-dcbc-4927-8c62-8da2554c7b7f)

not participating
![image](https://github.com/user-attachments/assets/1102916e-bfe3-491b-b542-633f2090f819)

no longer participating
![image](https://github.com/user-attachments/assets/72b41f84-e3e4-4e91-b535-da1be86a34a5)